### PR TITLE
Update INSTALL-from-source.md

### DIFF
--- a/INSTALL-from-source.md
+++ b/INSTALL-from-source.md
@@ -7,6 +7,7 @@ Build from sources you need:
 * gettext
 * GNU Readline
 * guile version 2.0
+* texinfo
 
 
 Additionally if installing from git you need:
@@ -19,7 +20,7 @@ Additionally if installing from git you need:
 Here is a `apt-get` command you can use to install on Debian-ish systems:
 
 ```console
-   $ sudo apt-get install git gcc pkg-config autoconf automake autopoint libreadline-dev make guile-2.0
+   $ sudo apt-get install git gcc pkg-config autoconf automake autopoint libreadline-dev make guile-2.0 texinfo
 ```
 
 Here is a `yum` command Redhat/CentOS:


### PR DESCRIPTION
When you don't have this package you get

makeinfo is part of texinfo

```
WARNING: 'makeinfo' is missing on your system.
         You should only need it if you modified a '.texi' file, or
         any other file indirectly affecting the aspect of the manual.
         You might want to install the Texinfo package:
         <https://www.gnu.org/software/texinfo/>
         The spurious makeinfo call might also be the consequence of
         using a buggy 'make' (AIX, DU, IRIX), in which case you might
         want to install GNU make:
         <https://www.gnu.org/software/make/>
```