### PR TITLE
Handle case of invalid trace command line option

### DIFF
--- a/main.c
+++ b/main.c
@@ -579,6 +579,8 @@ decode_trace_flags (stringlist_t *ppsz_tracing_opts)
           db_level = DB_BASIC | DB_TRACE;
         else if (0 == strcmp(*p, "read"))
           db_level |= DB_READ_MAKEFILES;
+        else
+          OS ( fatal, NILF, _("unknown trace command execution type `%s'"), *p);
       }
   }
 }


### PR DESCRIPTION
- This fix came to light through issue #40 "remake -xn isn't the same
   as remake -nx"
- Added a check for invalid trace exection command option (-x|--trace)