### PR TITLE
Remove '-C' and '-Werror' from AM_FLAGS

### DIFF
--- a/maintMakefile
+++ b/maintMakefile
@@ -32,7 +32,7 @@ PERLFLAGS := -w
 # We like mondo-warnings!
 # Also force comments to be preserved.  This helps when using ccache, in
 # combination with GCC 7's implicit-fallthrough warning.
-MAKE_CFLAGS := -C -Wall -Wextra -Werror -Wwrite-strings -Wshadow \
+MAKE_CFLAGS := -Wall -Wextra -Wwrite-strings -Wshadow \
 	-Wdeclaration-after-statement -Wbad-function-cast -Wformat-security \
 	-Wtype-limits -Wunused-but-set-parameter -Wlogical-op \
 	-Wignored-qualifiers # -Wformat-signedness  # CI's gcc can't handle this


### PR DESCRIPTION
Modify maintMakefile so remake compiles on macOS & *BSD

The same modification were done in remake-4-2: removal of '-C' and '-Werror' from MAKE_CFLAGS/AM_CFLAGS in maintMakefile.