### PR TITLE
Add missing target, remove dist files & modify git2cl

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -159,7 +159,6 @@ test_FILES =	tests/run_make_tests tests/run_make_tests.bat \
 EXTRA_DIST =	ChangeLog README build.sh.in build.cfg.in $(man_MANS) \
 		README.customs \
 		SCOPTIONS src/config.ami \
-		README.DOS builddos.bat src/configh.dos \
 		README.W32 build_w32.bat src/config.h.W32 \
 		src/debugger/Makefile \
 		src/gmk-default.scm src/gmk-default.h \

--- a/git2cl
+++ b/git2cl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2007, 2008 Simon Josefsson <simon@josefsson.org>
 # Copyright (C) 2007 Luis Mondesi <lemsx1@gmail.com>

--- a/maintMakefile
+++ b/maintMakefile
@@ -94,6 +94,13 @@ Basic.mk: Basic.mk.template .dep_segment Makefile
 	  $(word 2,$^) >>$@
 	chmod a-w $@
 
+build.sh.in: build.template Makefile
+	rm -f $@
+	sed -e 's@%objs%@$(patsubst %.o,%.$${OBJEXT},$(filter-out remote-%,$(make_OBJECTS)))@g' \
+	    -e 's@%globobjs%@$(patsubst %.c,%.$${OBJEXT},$(globsrc))@g' \
+	$< > $@
+	chmod a-w+x $@
+
 
 # Use automake to build a dependency list file, for Makebase.mk.
 #


### PR DESCRIPTION
A target for bulding `build.sh.in` was missing in `maintMakefile`

Since DOS is not a supported platform the files were gone before.
Therefore remove the dist related DOS files.

Replace shebang `/usr/bin/perl` with `/usr/bin/env perl` since perl's
location depends on the OS.