### PR TITLE
Working on getting `dist` and `distcheck` fixed 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -106,6 +106,8 @@ loadavg_SRCS =	lib/getloadavg.c
 
 make_SOURCES =	$(make_SRCS)
 
+EXTRA_make_SOURCES = src/mock.c
+
 noinst_HEADERS = src/buildargv.h src/commands.h src/debug.h src/debugger.h \
 				src/dep.h src/expand.h src/file.h src/file_basic.h \
 				src/filedef.h src/function.h src/getopt.h src/gettext.h \
@@ -159,12 +161,17 @@ test_FILES =	tests/run_make_tests tests/run_make_tests.bat \
 EXTRA_DIST =	ChangeLog README build.sh.in build.cfg.in $(man_MANS) \
 		README.customs \
 		SCOPTIONS src/config.ami \
-		README.DOS builddos.bat src/configh.dos \
 		README.W32 build_w32.bat src/config.h.W32 \
 		src/debugger/Makefile \
 		src/gmk-default.scm src/gmk-default.h \
 		NEWS.remake README.remake REMAKE.todo Rakefile \
 		$(mk_FILES) $(m4_FILES) $(test_FILES)
+
+# FIXME: Not sure why these src/w32 *.Po's & Makefile are left over
+#       but distcheck fails with them so they have to go, hasta la vista
+distclean-local:
+	find src/w32 -type f  -name 'libw32*.Po' -delete
+	rm -f src/w32/Makefile
 
 # --------------- Generate the Guile default module content
 

--- a/git2cl
+++ b/git2cl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Copyright (C) 2007, 2008 Simon Josefsson <simon@josefsson.org>
 # Copyright (C) 2007 Luis Mondesi <lemsx1@gmail.com>

--- a/maintMakefile
+++ b/maintMakefile
@@ -94,6 +94,13 @@ Basic.mk: Basic.mk.template .dep_segment Makefile
 	  $(word 2,$^) >>$@
 	chmod a-w $@
 
+build.sh.in: build.template Makefile
+	rm -f $@
+	sed -e 's@%objs%@$(patsubst %.o,%.$${OBJEXT},$(filter-out remote-%,$(make_OBJECTS)))@g' \
+	    -e 's@%globobjs%@$(patsubst %.c,%.$${OBJEXT},$(globsrc))@g' \
+	$< > $@
+	chmod a-w+x $@
+
 
 # Use automake to build a dependency list file, for Makebase.mk.
 #

--- a/unittest/Makefile.am
+++ b/unittest/Makefile.am
@@ -1,4 +1,5 @@
-AM_CPPFLAGS  = -I$(abs_top_srcdir)
+AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/lib
+
 test_profile_SOURCES = test_profile.c
 
 test_profile_LDADD = \


### PR DESCRIPTION
I got `make distcheck` to work, on Linux only for now.

On macOS `distclean` leaves behind two `*.c` file for tests it doesn't run. On FreeBSD I couldn't test it since the system is missing `tex` and trying to install it filled my little VPS' disk :)

Have a look if the PR works for you.

Edit: I f*ed up a bit maybe. This PR contains also the `make dist` PR, but merge seems to be happy ?