### PR TITLE
Fix a error print function call

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1473,9 +1473,9 @@ main (int argc, const char **argv, char **envp)
           }
         }
 #ifndef HAVE_LIBREADLINE
-      error (NILF,
+      O (error, NILF,
              "warning: you specified a debugger option, but you don't have readline support");
-      error (NILF,
+      O (error, NILF,
              "debugger support compiled in. Debugger options will be ignored.");
 #endif
     }


### PR DESCRIPTION
In main.c in case of _not_ HAVE_READLINE there wasn't used the O()
message macro. The compiler wasn't happy about that but since nobody not used readline it didn't pop up before