### PR TITLE
Check for compiler flags and use GNU grep

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -126,7 +126,8 @@ AM_CPPFLAGS =	-Isrc -I$(top_srcdir)/src -Ilib -I$(top_srcdir)/lib \
 		-DLIBDIR=\"$(libdir)\" -DINCLUDEDIR=\"$(includedir)\" \
 		-DLOCALEDIR=\"$(localedir)\"
 
-AM_CFLAGS =	$(GUILE_CFLAGS)
+AM_CFLAGS += $(GUILE_CFLAGS)
+make_CFLAGS    = $(AM_CFLAGS)
 
 if WINDOWSENV
   make_SOURCES += $(w32_SRCS)

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,9 @@ AC_PROG_LN_S
 AC_CHECK_PROG([AR], [ar], [ar], [ar])
 # Perl is needed for the test suite (only)
 AC_CHECK_PROG([PERL], [perl], [perl], [perl])
+# GNU grep is needed (OpenBSD)
+#AC_CHECK_PROG([ggrep], [grep])
+AC_PROG_GREP
 
 # Ruby 1.9 and RSPec are needed for the debugger test suite (only)
 AC_CHECK_PROG(RUBY, ruby, ruby, none)
@@ -659,6 +662,30 @@ Makefile build.cfg lib/Makefile po/Makefile.in doc/Makefile \
 ])
 # We don't need this: the standard automake output suffices for POSIX systems.
 #mk/Posix.mk
+
+# We like mondo-warnings!
+# Also force comments to be preserved.  This helps when using ccache, in
+# combination with GCC 7's implicit-fallthrough warning.
+# check for some supported compiler flags, instead of have 'em hard coded in
+# maintMakefile
+# -Werror is too much, on differentt platform we get different warnings FOR
+# e.g. guile headers.
+# AX_CHECK_COMPILE_FLAG([-Werrror], [AM_CFLAGS="$AM_CFLAGS -Werror"])
+AX_CHECK_COMPILE_FLAG([-C], [AM_CFLAGS="$AM_CFLAGS -C"])
+AX_CHECK_COMPILE_FLAG([-Wall],[AM_CFLAGS="$AM_CFLAGS -Wall"])
+AX_CHECK_COMPILE_FLAG([-Wextra], [AM_CFLAGS="$AM_CFLAGS -Wextra"])
+AX_CHECK_COMPILE_FLAG([-Wwrite-strings], [AM_CFLAGS="$AM_CFLAGS -Wwrite-strings"])
+AX_CHECK_COMPILE_FLAG([-Wshadow], [AM_CFLAGS="$AM_CFLAGS -Wshadow"])
+AX_CHECK_COMPILE_FLAG([-Wdeclaration-after-statement], [AM_CFLAGS="$AM_CFLAGS -Wdeclaration-after-statement"])
+AX_CHECK_COMPILE_FLAG([-Wbad-function-cast], [AM_CFLAGS="$AM_CFLAGS -Wbad-function-cast"])
+AX_CHECK_COMPILE_FLAG([-Wformat-security], [AM_CFLAGS="$AM_CFLAGS -Wformat-security"])
+AX_CHECK_COMPILE_FLAG([-Wtype-limits], [AM_CFLAGS="$AM_CFLAGS -Wtype-limits"])
+AX_CHECK_COMPILE_FLAG([-Wunused-but-set-parameter], [AM_CFLAGS="$AM_CFLAGS -Wunused-but-set-parameter"])
+AX_CHECK_COMPILE_FLAG([-Wlogical-op], [AM_CFLAGS="$AM_CFLAGS -Wlogical-op"])
+AX_CHECK_COMPILE_FLAG([-Wignored-qualifiers], [AM_CFLAGS="$AM_CFLAGS -Wignored-qualifiers"])
+AX_CHECK_COMPILE_FLAG([-Wformat-signedness], [AM_CFLAGS="$AM_CFLAGS -Wformat-signedness"])
+AX_CHECK_COMPILE_FLAG([-Wduplicated-conk], [AM_CFLAGS="$AM_CFLAGS -Wduplicated-conk"])
+AC_SUBST([AM_CFLAGS])
 
 # OK, do it!
 

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/maintMakefile
+++ b/maintMakefile
@@ -36,12 +36,6 @@ PERLFLAGS ?=
 # We like mondo-warnings!
 # Also force comments to be preserved.  This helps when using ccache, in
 # combination with GCC 7's implicit-fallthrough warning.
-MAKE_CFLAGS := -Wall -Wextra -Wwrite-strings -Wshadow \
-	-Wdeclaration-after-statement -Wbad-function-cast -Wformat-security \
-	-Wtype-limits -Wunused-but-set-parameter -Wlogical-op \
-	-Wignored-qualifiers # -Wformat-signedness  # CI's gcc can't handle this
-
-AM_CFLAGS += $(MAKE_CFLAGS)
 
 # Unfortunately the Guile headers are sometimes broken.  Convince GCC
 # to treat them as system headers so warnings are ignored.
@@ -364,8 +358,8 @@ changelog-check:
 #: Pull in translation files from https://translationproject.org
 po-check:
 	if test -f po/POTFILES.in; then \
-	  grep '^[^#]' po/POTFILES.in | sort > $@-1; \
-	  find [a-z]* -name '*.[ch]' | xargs grep -l '\b_(' | grep -v src/makeint.h | grep -v lib/ | sort > $@-2; \
+	  $(GREP) '^[^#]' po/POTFILES.in | sort > $@-1; \
+	  find [a-z]* -name '*.[ch]' | xargs $(GREP) -l '\b_(' | $(GREP) -v src/makeint.h | $(GREP) -v lib/ | sort > $@-2; \
 	  diff -u $@-1 $@-2 || exit 1; \
 	  rm -f $@-1 $@-2; \
 	fi


### PR DESCRIPTION
In configure.ac check for valid compiler CFLAGS instead of them
hardcoded in `maintMakefile`. Still not perfect since Apple for example
to not return error for flags its compiler doesn't support.

Look for GNU grep instead of the system one. The `po-check` target uses
word boundary metacharacter `\b`. Asking the internet is seems as if
there are no overlapping word boundary metacharacters between the POSIX
and GNU grep implementations. And the stock OpenBSD is not GNU
compatible.