### PR TITLE
Towards getting "make distcheck" working.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /build.cfg
 /build.sh
 /build.sh.in
+/config
 /config.ami
 /config.dos
 /config.h
@@ -42,6 +43,7 @@
 /remake-*.tar.bz2
 /remake-*.tar.gz
 /remake-*.tar.lz
+/remake-4.*+dbg-*
 /stamp-h1
 /tmp
 /w32

--- a/Makefile.am
+++ b/Makefile.am
@@ -189,7 +189,7 @@ src/gmk-default.h: $(top_srcdir)/src/gmk-default.scm
 #: Install the mk and tests subdirectories
 dist-hook:
 	(cd $(top_srcdir); \
-	 sub=`find src/w32 tests/scripts -follow \( -name .git -o -name .deps -o -name work -o -name .gitignore -o -name \*.orig -o -name \*.rej -o -name \*~ -o -name \*.out -o -name Makefile \) -prune -o -type f -print`; \
+	 sub=`find src tests/scripts -follow \( -name .git -o -name .deps -o -name work -o -name .gitignore -o -name \*.orig -o -name \*.rej -o -name \*~ -o -name \*.out -o -name Makefile \) -prune -o -type f -print`; \
 	 tar chf - $$sub) \
 	| (cd $(distdir); tar xfBp -)
 

--- a/NEWS
+++ b/NEWS
@@ -1,8 +1,10 @@
-Version 4.3+dbg-1.4
+Version 4.3+dbg-1.5
 
-Base on make 4.3 
+Base on make 4.3
 
-Version 4.2.1+dbg-1.4
+Add "-c" "--search-parent" option
+
+Version 4.2.1+dbg-1.5
 
 Two small but important changes...
 

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 
 define(_MAKE_VERSION_, 4.3)
-AC_INIT([remake],[_MAKE_VERSION_+dbg-1.4],[https://github.com/rocky/remake/issues])
+AC_INIT([remake],[_MAKE_VERSION_+dbg-1.5],[https://github.com/rocky/remake/issues])
 
 # These are used in maintMakefile
 MAKE_VERSION=_MAKE_VERSION_
@@ -35,6 +35,15 @@ AC_CONFIG_HEADERS([src/config.h])
 AM_MAINTAINER_MODE
 
 AC_CONFIG_LIBOBJ_DIR([lib])
+
+AH_TOP(
+/* Guard against #including config.h more than once */
+#ifndef INCLUDED_REMAKE_CONFIG_H
+#define INCLUDED_REMAKE_CONFIG_H
+)
+AH_BOTTOM(
+#endif /*INCLUDED_REMAKE_CONFIG_H*/
+)
 
 # Automake setup
 # We have to enable "foreign" because ChangeLog is auto-generated

--- a/src/dir.c
+++ b/src/dir.c
@@ -1088,22 +1088,9 @@ print_dir_data_base (void)
             printf (_("# %s: could not be stat'd.\n"), dir->name);
           else if (dir->contents->dirfiles.ht_vec == 0)
             {
-#ifdef WINDOWS32
-              printf (_("# %s (key %s, mtime %I64u): could not be opened.\n"),
-                      dir->name, dir->contents->path_key,
-                      (unsigned long long)dir->contents->mtime);
-#else  /* WINDOWS32 */
-#ifdef VMS_INO_T
-              printf (_("# %s (device %d, inode [%d,%d,%d]): could not be opened.\n"),
-                      dir->name, dir->contents->dev,
-                      dir->contents->ino[0], dir->contents->ino[1],
-                      dir->contents->ino[2]);
-#else
               printf (_("# %s (device %ld, inode %ld): could not be opened.\n"),
                       dir->name, (long int) dir->contents->dev,
                       (long int) dir->contents->ino);
-#endif
-#endif /* WINDOWS32 */
             }
           else
             {

--- a/unittest/test_profile.c
+++ b/unittest/test_profile.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2015, 2017 R. Bernstein <rocky@gnu.org>
+Copyright (C) 2015, 2017, 2020 R. Bernstein <rocky@gnu.org>
 This file is part of GNU Make (remake variant).
 
 GNU Make is free software; you can redistribute it and/or modify
@@ -23,6 +23,7 @@ Boston, MA 02111-1307, USA.  */
 #include "../src/profile.h"
 int main(int argc, const char * const* argv) {
   bool rc = init_callgrind(PACKAGE_TARNAME " " PACKAGE_VERSION, argv);
+  (void)argc;
   init_hash_files();
   if (rc) {
     file_t *target = enter_file("Makefile");


### PR DESCRIPTION
configure.ac: guard against including more than once. Bumb version.
NEWS: obligatory change. FIXME: use NEW-readme.md instead
src/dir.c: some WINDOWS #ifdefs were causing warnings, remove WINDOWS32
unittest/test_profile.c: squelch a warning about argc not used in test program.