### PR TITLE
Fix "virtual memory exhausted" in (debugger)...

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -8,6 +8,7 @@
 /make.info
 /make.info-1
 /make.info-2
+/make.t2p
 /make_abt.html
 /mdb.info
 /remake.aux

--- a/doc/remake.texi
+++ b/doc/remake.texi
@@ -1296,10 +1296,40 @@ Another way to get into the debugger is to make a specific all inside
 your Makefile using the @code{debugger} built-in function.
 
 @smallexample
-# Makefile to show an explicit call to the debugger
-all:
- 	$(debugger )
- 	echo "all here"
+foo: bar
+
+debug:
+     $(debugger "debug target break")
+
+bar:
+     $(debugger "first bar command")
+     @@echo hi
+
+baz: debug
+     @@echo hello again
+@end smallexample
+
+@smallexample
+$ remake -f /tmp/foo.Makefile
+debugger() function caled with parameter "bar called"
+break
+:o (/tmp/foo.Makefile:3)
+bar
+remake<0> where
+=>#0  bar at /tmp/foo.Makefile:6
+  #1  foo at /tmp/foo.Makefile:1
+  remake<0> quit
+  remake: That's all, folks...
+
+$ remake -f /tmp/foo.Makefile baz
+debugger() function caled with parameter "debug target break"
+ break
+:o (/src/external-vcs/github/rocky/remake/tmp/debugger.Makefile:3)
+debug
+remake<0> where
+=>#0  debug at /tmp/foo.Makefile:3
+  #1  baz at /tmp/foo.Makefile:10
+remake<0>
 @end smallexample
 
 @node Quitting the GNU Make debugger

--- a/docs/debugger/entry.rst
+++ b/docs/debugger/entry.rst
@@ -47,20 +47,40 @@ Here is an Example:
 
           foo: bar
 
+	  debug:
+                $(debugger "debug target break")
+
           bar:
-                $(debugger "bar called")
+                $(debugger "first bar command")
+		@echo hi
+
+	  baz: debug
+	        @echo hello again
 
 
 .. code:: console
 
-          ./make -f /tmp/foo.Makefile
-          :o (/tmp/foo.Makefile:3)
+          $ remake -f /tmp/foo.Makefile
+	  debugger() function caled with parameter "bar called"
+	  break
+	  :o (/tmp/foo.Makefile:3)
           bar
           remake<0> where
-          =>#0  bar at /tmp/foo.Makefile:3
+          =>#0  bar at /tmp/foo.Makefile:6
             #1  foo at /tmp/foo.Makefile:1
-          foo: bar
+          remake<0> quit
+	  remake: That's all, folks...
+
+          $ remake -f /tmp/foo.Makefile baz
+	  debugger() function caled with parameter "debug target break"
+	  break
+	  :o (/src/external-vcs/github/rocky/remake/tmp/debugger.Makefile:3)
+          debug
+          remake<0> where
+          =>#0  debug at /tmp/foo.Makefile:3
+            #1  baz at /tmp/foo.Makefile:10
           remake<0>
+
 
 Entering the debugger when `remake` encounters an error
 =======================================================

--- a/src/function.c
+++ b/src/function.c
@@ -1340,21 +1340,19 @@ func_eval (char *o, char **argv, const char *funcname UNUSED)
 
 
 /*
-  $(debugger )
+  $(debugger "tag-name")
 
-  Always resolves to the empty string.
+  Always returns the empty string.
 
-  Treat the arguments as a segment of makefile, and parse them.
+  Call the internal debugger.
 */
 
 static char *
-func_debugger (char *o, char **argv UNUSED, const char *funcname UNUSED)
+func_debugger (char *o, char **argv, const char *funcname UNUSED)
 {
-  debug_return_t rc;
-  static char buffer[10];
-  rc = enter_debugger(p_stack_top, NULL, 0, DEBUG_EXPLICIT_CALL);
-  snprintf(buffer, sizeof(buffer), "%u", rc);
-  o = buffer;
+  printf("debugger() function caled with parameter %s\n", argv[0]);
+  (void) enter_debugger(p_stack_top, NULL, 0, DEBUG_EXPLICIT_CALL);
+  o = variable_buffer_output (o, "", 0);
   return o;
 }
 


### PR DESCRIPTION
and add a parameter to the debugger call as a way to tag
the point of call.

Update docs to reflect the change.