### PR TITLE
"list" command improvments...

### DIFF
--- a/docs/debugger/commands/files/list.rst
+++ b/docs/debugger/commands/files/list.rst
@@ -29,4 +29,4 @@ Examples:
 
 .. seealso::
 
-   :ref:`edit <edit>`.
+   ref:`target <target>`, :ref:`edit <edit>`.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -193,7 +193,9 @@ opted for the slightly shorter source code without some enclosing braces.*
 I understand how this ugly code hard-to-read code most likely came
 about in GNU Make. Been there and done that myself too.
 
-In the early days to gain traction and support, a project wants to support lots of different platforms and OS's, even obscure ones. To get going, you'll probably do that in the most expedient day.
+In the early days to gain traction and support, a project wants to
+support lots of different platforms and OS's, even obscure ones. To
+get going, you'll probably do that in the most expedient way.
 
 But again, that was then and this is now.
 

--- a/src/debugger/command/help/list.h
+++ b/src/debugger/command/help/list.h
@@ -1,2 +1,8 @@
-#define list_HELP_TEXT						\
-  "List target dependencies and commands for TARGET or LINE NUMBER."
+#define list_HELP_TEXT						       \
+  "List target dependencies and commands for TARGET or LINE NUMBER.\n" \
+  "Without a target name or line number, use the current target.\n"	\
+  "A target name of '-' will use the parent target on the target stack.\n" \
+  "\n"									\
+  "See also:\n"								\
+  "---------\n"								\
+  "`target`, `edit`"

--- a/src/debugger/command/list.h
+++ b/src/debugger/command/list.h
@@ -76,6 +76,7 @@ dbg_cmd_list(char *psz_arg)
     return debug_cmd_error;
   }
   print_floc_prefix(&p_target->floc);
+  if (p_target->description) printf("\n");
   target_cmd = CALLOC(char, strlen(psz_target) + 1 + strlen(DEPENDS_COMMANDS));
   sprintf(target_cmd, "%s%s", psz_target, DEPENDS_COMMANDS);
   return dbg_cmd_target(target_cmd);
@@ -86,11 +87,6 @@ dbg_cmd_list_init(unsigned int c)
 {
   short_command[c].func = &dbg_cmd_list;
   short_command[c].use = _("list [TARGET|LINE-NUMBER]");
-  short_command[c].doc =
-    _("List target dependencies and commands for TARGET or LINE NUMBER.\n"
-"Without a target name or line number, use the current target.\n"
-"A target name of '-' will use the parent target on the target stack.\n"
- );
 }
 
 


### PR DESCRIPTION
list.h: when there was a description for a target, the description was
shown at the end of the file location instead of on a new line.

RsT docs: expand and regularize a little