### PR TITLE
Change description of --tasks

### DIFF
--- a/doc/make.1
+++ b/doc/make.1
@@ -131,7 +131,8 @@ Print a list of explicitly-named targets found in read-in makefiles.
 .TP 0.5i
 .BR \-\-tasks
 Print a list of explicitly-named targets found in read-in makefiles which
-have commands associated with them and are either phony or are not implicit.
+have description comments. A description comment is added by putting
+a single comment before the target that starts with '#:'.
 
 .TP 0.5i
 .B\-x, " \-\-trace [=FLAGS]"

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -47,23 +47,23 @@ Here is an example. Consider this `Makefile`:
 
     #: This is the main target
     all:
-  	echo all here
+  	@echo all here
 
-    #: test things
+    #: Test things
     check:
-	echo check here
+	@echo check here
 
     #: Build distribution
     dist:
-	echo dist here
+	@echo dist here
 
 Running `remake --tasks` gives:
 
 .. code:: console
 
-    all         # This is the main target
-    check       # test things
-    dist        # Build distribution
+    all                  This is the main target
+    check                Test things
+    dist                 Build distribution
 
 Searching for a Makefile in Parent Directories
 ----------------------------------------------

--- a/docs/manpage.rst
+++ b/docs/manpage.rst
@@ -55,8 +55,32 @@ Print a list of explicitly named targets found in read-in makefiles.
 
 :--tasks:
 
-Print a list of explicitly named targets found in read-in makefiles which
-have commands associated with them and are either phony or are not implicit.
+Print a list of explicitly-named targets found in read-in makefiles which
+have description comments. A description comment is added by putting
+a single comment before the target that starts with `#:`. For example,
+for this Makefile:
+
+.. code:: Makefile
+
+    #: This is the main target
+    all:
+  	@echo all here
+
+    #: Test things
+    check:
+	@echo check here
+
+    #: Build distribution
+    dist:
+	@echo dist here
+
+Running `remake --tasks` gives:
+
+.. code:: console
+
+    all                  This is the main target
+    check                Test things
+    dist                 Build distribution
 
 :-x | --trace:
 

--- a/src/debugger/command/write.h
+++ b/src/debugger/command/write.h
@@ -112,7 +112,8 @@ dbg_cmd_write(char *psz_args)
 		p_target->floc.filenm, p_target->floc.lineno);
       }
 
-      /* FIXME: this code duplicaes some code in file.c: print_target_props. DRY. */
+      /* FIXME: this code duplicates some code in file.c:
+         print_target_props. DRY. */
       fprintf (outfd,
                "## %s:%s", p_target->name,
                p_target->double_colon ? ":" : "");
@@ -193,13 +194,6 @@ dbg_cmd_write_init(unsigned int c)
 {
   short_command[c].func = &dbg_cmd_write;
   short_command[c].use =  _("write [TARGET [FILENAME]]");
-  short_command[c].doc  =
-    _("writes the commands associated of a target to a file with MAKE\n"
-      "variables expanded. If no target given, the basename of the current\n"
-      "is used. If a filename is supplied it is used. If it is the string\n"
-      "\"here\", we write the output to stdout. If no filename is\n"
-      "given then create the filename by prepending a directory name to\n"
-      "the target name and then append \".sh\".");
 }
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -329,8 +329,8 @@ static const char *const usage[] =
     N_("\
   --targets                   Give list of explicitly-named targets.\n"),
     N_("\
-  --tasks                     Give list of explicitly-named targets which\n\
-                              have commands associated with them.\n"),
+  --tasks                     Give list of targets which have descriptions\n\
+                              associated with them.\n"),
     N_("\
   -t, --touch                 Touch targets instead of remaking them.\n"),
     N_("\


### PR DESCRIPTION
I have come to the opinion `--tasks` should be
simpler in how it works.

Before, `remake --tasks` did some magic to see if a target was
"interesting", and one of the criteria was if it had a description
associated with it.

After years of using, I believe `--task`s should just look for targets
with descriptions. If that encourages people to document targets,
all the better.

Overall in this release I have elevated making use of target descriptions.

When we show a target now using the `target` command, we show any
description it has. And there is a `info tasks` which shows all targets
with descriptions.

Again, in my own experience here and in other projects, adding comments
and documentation is a good thing (tm); I think `remake` should be
doing whatever it can to promote this activity.

If limiting the checking that `--tasks` has to do to find its list of
targets nudges people into using the description comment more often,
then that in my opinion is a good thing.