### PR TITLE
Add "info tasks"; regularize/expand doc

### DIFF
--- a/docs/debugger/commands/breakpoints.rst
+++ b/docs/debugger/commands/breakpoints.rst
@@ -1,8 +1,8 @@
 .. index:: breakpoints
 .. _breakpoints:
 
-Breakpoints
-===========
+Breakpoints (`break`, `delete`)
+===============================
 
 A *breakpoint* causes `remake` to stop when it reaches a Makefile target.
 

--- a/docs/debugger/commands/data.rst
+++ b/docs/debugger/commands/data.rst
@@ -1,7 +1,9 @@
-Data
-====
+.. index: data
+.. _data:
 
-Examining data.
+
+Examining data (`print`, `target`, `expand`, `write`)
+=====================================================
 
 .. toctree::
    :maxdepth: 1

--- a/docs/debugger/commands/files.rst
+++ b/docs/debugger/commands/files.rst
@@ -1,7 +1,9 @@
-Files
-=====
+.. index:: files
+.. _files:
 
-Specifying and examining files.
+Specifying and examining files (`edit`, `list`, `load`)
+=======================================================
+
 
 .. toctree::
    :maxdepth: 1

--- a/docs/debugger/commands/info.rst
+++ b/docs/debugger/commands/info.rst
@@ -1,5 +1,8 @@
-Info
-====
+.. index:: info
+.. _info:
+
+Information from the Debugged Session (`break`, `files`, `line`, `program`, `rules`, `target`, `targets`, `tasks`, `variables`)
+===============================================================================================================================
 
 **info** [ *info-subcommand* ]
 
@@ -21,4 +24,5 @@ Type `info` for a list of info subcommands and what they do. Type ``help info`` 
    info/rules
    info/target
    info/targets
+   info/tasks
    info/variables

--- a/docs/debugger/commands/info/break.rst
+++ b/docs/debugger/commands/info/break.rst
@@ -1,8 +1,8 @@
 .. index:: info; breakpoints
 .. _info_breakpoints:
 
-Info Breakpoints
-----------------
+List all Breakpoints (`info break`)
+-----------------------------------
 
 **info break**
 

--- a/docs/debugger/commands/info/files.rst
+++ b/docs/debugger/commands/info/files.rst
@@ -1,8 +1,8 @@
 .. index:: info; files
 .. _info_files:
 
-Info Files
-------------
+Show Read-in Files (`info files`)
+---------------------------------
 
 **info files**
 

--- a/docs/debugger/commands/info/frame.rst
+++ b/docs/debugger/commands/info/frame.rst
@@ -1,8 +1,8 @@
 .. index:: info; frame
 .. _info_frame:
 
-Info Frame
------------
+Show Target Stack Frame (`info frame`)
+--------------------------------------
 
 **info frame**
 

--- a/docs/debugger/commands/info/line.rst
+++ b/docs/debugger/commands/info/line.rst
@@ -1,8 +1,8 @@
 .. index:: info; line
 .. _info_line:
 
-Info Line
----------
+`Show the Current Line (`info line`)
+------------------------------------
 
 **info line**
 

--- a/docs/debugger/commands/info/program.rst
+++ b/docs/debugger/commands/info/program.rst
@@ -1,8 +1,8 @@
 .. index:: info; program
 .. _info_program:
 
-Info Program
-------------
+Show Makefile Information (`info program`)
+------------------------------------------
 
 **info program**
 

--- a/docs/debugger/commands/info/rules.rst
+++ b/docs/debugger/commands/info/rules.rst
@@ -1,8 +1,8 @@
 .. index:: info; rules
 .. _info_rules:
 
-Info Rules
-------------
+Show Implicit or Pattern Rules (`info rules`)
+---------------------------------------------
 
 **info rules** [ **verbose** ]
 

--- a/docs/debugger/commands/info/target.rst
+++ b/docs/debugger/commands/info/target.rst
@@ -1,8 +1,8 @@
 .. index:: info; target
 .. _info_target:
 
-Info Target
------------
+Show Target Name `info target`)
+-------------------------------
 
 **info target**
 

--- a/docs/debugger/commands/info/targets.rst
+++ b/docs/debugger/commands/info/targets.rst
@@ -1,8 +1,8 @@
 .. index:: info; target
 .. _info_targets:
 
-Info Targets
-------------
+Show Targets found in Makefiles (`info targets`)
+------------------------------------------------
 
 **info targets** [ **names** | **positions** | **tasks** | **all** ]
 
@@ -31,4 +31,4 @@ Example:
 
 .. seealso::
 
-   :ref:`target <target>`, and :ref:`info target <info_target>`.
+   :ref:`info tasks <info_tasks>`, :ref:`target <target>`, and :ref:`info target <info_target>`.

--- a/docs/debugger/commands/info/tasks.rst
+++ b/docs/debugger/commands/info/tasks.rst
@@ -1,0 +1,43 @@
+.. index:: info; tasks
+.. _info_tasks:
+
+Show Targets with Descriptions (`info tasks`)
+---------------------------------------------
+
+**info tasks**
+
+Show the targets that have descriptions.
+
+A Description comment is a single line before a target that starts `#:`
+
+
+Example:
+++++++++
+
+.. code:: Makefile
+
+    #: This is the main target
+    all:
+  	@echo all here
+
+    #: Test things
+    check:
+	@echo check here
+
+    #: Build distribution
+    dist:
+	@echo dist here
+
+
+.. code::
+
+    remake<0> info tasks
+
+    all                  This is the main target
+    check                Test things
+    dist                 Build distribution
+
+
+.. seealso::
+
+   :ref:`info target <info_target>`.

--- a/docs/debugger/commands/os.rst
+++ b/docs/debugger/commands/os.rst
@@ -1,4 +1,5 @@
-.. _eval:
+.. index:: OS-interfacing commmands
+.. _os:
 
 Interfacing to the OS (`cd`, `pwd`, `shell`)
 ============================================

--- a/docs/debugger/commands/running.rst
+++ b/docs/debugger/commands/running.rst
@@ -1,5 +1,8 @@
-Running
-=======
+.. index:: running
+.. _running:
+
+Run-Changing Commands (`continue`, `finish`, `next`, `quit`, `run`, `skip`, `step`)
+===================================================================================
 
 Running, restarting, or stopping the program.
 

--- a/docs/debugger/commands/set.rst
+++ b/docs/debugger/commands/set.rst
@@ -1,3 +1,4 @@
+.. index:: set
 .. _set:
 
 **set** [ *set-subcommand* ]
@@ -11,8 +12,8 @@ for a summary list of set subcommands.
 
 All of the "set" commands have a corresponding :ref:`show <show>` command.
 
-Set
-===
+Set (`basename`, `debug`, `ignore-errors`, `keep-going`, `setq`, `setx`, `silent`)
+==================================================================================
 
 Modifies parts of the debugger environment.  You can see these
 environment settings with the :ref:`show <show>` command.

--- a/docs/debugger/commands/show.rst
+++ b/docs/debugger/commands/show.rst
@@ -1,4 +1,6 @@
+.. index:: show
 .. _show:
+
 
 **show**  [ *subcommand* ]
 
@@ -7,8 +9,8 @@ nn
 Type `show` for a list of show subcommands and what they do. Type ``help show`` for a summmary list of show subcommands.  Many of the "show"
 commands have a corresponding :ref:`set <set>` command.
 
-Show
-====
+Show (`args`, `basename`, `commands`, `debug`, `ignore-errors`, `keep-going`, `silent`, `version`)
+==================================================================================================
 
 .. toctree::
    :maxdepth: 1

--- a/docs/debugger/commands/stack.rst
+++ b/docs/debugger/commands/stack.rst
@@ -1,17 +1,17 @@
-Stack
-=====
+.. index:: stack
+.. _stack:
 
-Examining the call stack.
+Examining the Target Stack (`backtrace`, `frame`, `up`, `down`)
+===============================================================
 
-The call stack is made up of stack frames.  The debugger assigns
-numbers to stack frames counting from zero for the innermost
-(currently executing) frame.
+The target stack is made up of targets linked by a dependency
+from one target on the next.  The debugger assigns numbers to target frames counting
+from zero for the innermost or currently executing target.
 
-At any time the debugger identifies one frame as the "selected" frame.
-Variable lookups are done with respect to the selected frame.  When
-the program being debugged stops, the debugger selects the innermost
-frame.  The commands below can be used to select other frames by
-number or address.
+At any time the debugger identifies one target as the "selected"
+target.  When the program being debugged stops, the debugger selects
+the innermost targets.  The commands below can be used to select other
+targets in the target stack by number.
 
 
 .. toctree::

--- a/docs/debugger/commands/stack/backtrace.rst
+++ b/docs/debugger/commands/stack/backtrace.rst
@@ -1,7 +1,7 @@
 .. index:: backtrace
 .. _backtrace:
 
-Show target stack (`backtrace`)
+Show Target Stack (`backtrace`)
 -------------------------------
 
 **backtrace** [*count*]

--- a/docs/debugger/commands/stack/down.rst
+++ b/docs/debugger/commands/stack/down.rst
@@ -1,7 +1,7 @@
 .. index:: down
 .. _down:
 
-Relative Motion towards a more-recent Target (`down`)
+Relative Motion towards a More-Recent Target (`down`)
 -----------------------------------------------------
 
 **down** [ *count* ]

--- a/docs/debugger/commands/stack/up.rst
+++ b/docs/debugger/commands/stack/up.rst
@@ -1,7 +1,7 @@
 .. index:: up
 .. _up:
 
-Relative Target Motion towards a more-recent Target (`up`)
+Relative Target Motion towards a Less-Recent Target (`up`)
 ----------------------------------------------------------
 
 **up** [ *count* ]


### PR DESCRIPTION
Noticed `info tasks` was missing in missing in going over release notes.