### PR TITLE
Disable -c testing...

### DIFF
--- a/tests/scripts/options/dash-lowercase-c
+++ b/tests/scripts/options/dash-lowercase-c
@@ -1,7 +1,13 @@
 #                                                                    -*-perl-*-
 
-$description = "This script tests to make sure that Remke looks for
-parent default makefiles in the correct order (GNUmakefile,makefile,Makefile)";
+$description = "This script tests to make sure that Remake looks for
+parent Makefiles which -c option is given";
+
+# Rocky: skip for now
+$details = "\
+FIXME: figure out how to test in a way that doesn't mess up surrounding test
+that might be run in parallel.";
+return -1;
 
 mkdir "work/options/testing";
 chdir "work/options/testing";


### PR DESCRIPTION
Canging directories is having a bad effect
on surrounding tests, e.g. dash-l which sometimes can get run in
parallel with dash-lowercase-c

The test framework really isn't set up for making directories and
removing them cleanly afterwards, or isolating each tests environment
so one can't have a bad effect on another.

And the test code here isn't doing the trick either.