### PR TITLE
WIP - debugger commands, "break", "comment", "cd" and "info" in their own objects

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,6 +70,12 @@ AM_CFLAGS += $(GUILE_CFLAGS)
 
 make_SOURCES += src/posixos.c
 
+# FIXME: In order to make "make distcheck" work, we need to include
+# things from the top lib directory. In particular this includes
+# "lib/findprog.h" which is used by "src/jobs.c" for POSIX spawn.
+DEFAULT_INCLUDES = -I$(top_srcdir)/lib -I.@am__isrc@ -I$(top_builddir)/src
+
+
 if USE_CUSTOMS
   # make_SOURCES += src/remote-cstms.c src/mock.c
   make_SOURCES += src/remote-cstms.c

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -768,7 +768,7 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf and *.qsf.
 
-FILE_PATTERNS          = *.h
+FILE_PATTERNS          = *.h *.c
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/doc/readthedocs/debugger/commands/running/finish.rst
+++ b/doc/readthedocs/debugger/commands/running/finish.rst
@@ -6,6 +6,8 @@ Step out (`finish`)
 
 **finish** [ *count* ]
 
+Run to the completion of the target, which is also known as "step out".
+
 With no arguments, `remake` runs to the end of the target. Any prerequisite
 checking and building that needs to occur is done and any shell commands
 that occur get run.

--- a/libdebugger/Makefile.am
+++ b/libdebugger/Makefile.am
@@ -52,6 +52,11 @@ libdebugger_a_SOURCES =  \
 	command/chdir.c \
 	command/comment.c \
 	command/delete.c \
+	command/down.c \
+	command/finish.c \
+	command/frame.c \
+	command/list.c \
+	command/up.c \
 	break.c \
 	cmd.c 	\
 	fns.c 	\

--- a/libdebugger/Makefile.am
+++ b/libdebugger/Makefile.am
@@ -1,7 +1,17 @@
 noinst_HEADERS = commands.h debugger.h
 noinst_LIBRARIES = libdebugger.a
-libdebugger_a_SOURCES =  \
+
+# Because there is both a break.c and a command/break.c we need
+# to specify the latter explicitly.
+DEBUGGER_COMMANDS_C = \
 	command/break.c \
+	command/info.c \
+	$(wildcard command/*.c)
+
+libdebugger_a_SOURCES =  \
+	$(DEBUGGER_COMMANDS_C) \
+	command/chdir.c \
+	command/comment.c \
 	break.c \
 	cmd.c 	\
 	fns.c 	\
@@ -12,9 +22,3 @@ libdebugger_a_SOURCES =  \
 #: Reissue building this target in parent directory
 doxygen readthedocs:
 	$(MAKE) -C .. $@
-
-#DEBUGGER_H = \
-#	$(wildcard src/debugger/*.h) \
-#	$(wildcard src/debugger/command/*.h) \
-#	$(wildcard src/debugger/command/help/*.h)
-#

--- a/libdebugger/Makefile.am
+++ b/libdebugger/Makefile.am
@@ -1,4 +1,42 @@
-noinst_HEADERS = commands.h debugger.h
+noinst_HEADERS = \
+	break.h \
+	cmd.h \
+	commands.h \
+	debugger.h \
+	command/help/break.h \
+	command/help/chdir.h \
+	command/help/comment.h \
+	command/help/continue.h \
+	command/help/delete.h \
+	command/help/down.h \
+	command/help/edit.h \
+	command/help/expand.h \
+	command/help/finish.h \
+	command/help/frame.h \
+	command/help/help.h \
+	command/help/info.h \
+	command/help/list.h \
+	command/help/load.h \
+	command/help/next.h \
+	command/help/print.h \
+	command/help/pwd.h \
+	command/help/quit.h \
+	command/help/run.h \
+	command/help/set.h \
+	command/help/setq.h \
+	command/help/setqx.h \
+	command/help/shell.h \
+	command/help/show.h \
+	command/help/skip.h \
+	command/help/source.h \
+	command/help/step.h \
+	command/help/target.h \
+	command/help/up.h \
+	command/help/where.h \
+	command/help/write.h \
+	file2line.h \
+	subcmd.h
+
 noinst_LIBRARIES = libdebugger.a
 
 # Because there is both a break.c and a command/break.c we need
@@ -6,6 +44,7 @@ noinst_LIBRARIES = libdebugger.a
 DEBUGGER_COMMANDS_C = \
 	command/break.c \
 	command/info.c \
+	$(wildcard command/*.h)
 	$(wildcard command/*.c)
 
 libdebugger_a_SOURCES =  \
@@ -15,9 +54,21 @@ libdebugger_a_SOURCES =  \
 	break.c \
 	cmd.c 	\
 	fns.c 	\
+	fns.h \
 	file2line.c 	\
+	info.h \
 	msg.c 	\
-	stack.c
+	msg.h \
+	stack.c \
+	stack.h
+
+# FIXME: In order to make "make distcheck" work, we need to include
+# things from the top src directory. In particular this includes
+# "src/gettext.h" which is used by "src/makeint.h" when <gettext.h> is not
+# found.
+#
+# Some debugger commands include "makeint.h".
+DEFAULT_INCLUDES = -I$(top_srcdir)/src -I.@am__isrc@ -I$(top_builddir)/src
 
 #: Reissue building this target in parent directory
 doxygen readthedocs:

--- a/libdebugger/Makefile.am
+++ b/libdebugger/Makefile.am
@@ -1,6 +1,7 @@
-noinst_HEADERS = debugger.h
+noinst_HEADERS = commands.h debugger.h
 noinst_LIBRARIES = libdebugger.a
 libdebugger_a_SOURCES =  \
+	command/break.c \
 	break.c \
 	cmd.c 	\
 	fns.c 	\

--- a/libdebugger/Makefile.am
+++ b/libdebugger/Makefile.am
@@ -51,6 +51,7 @@ libdebugger_a_SOURCES =  \
 	$(DEBUGGER_COMMANDS_C) \
 	command/chdir.c \
 	command/comment.c \
+	command/delete.c \
 	break.c \
 	cmd.c 	\
 	fns.c 	\

--- a/libdebugger/cmd.c
+++ b/libdebugger/cmd.c
@@ -182,14 +182,10 @@ find_command (const char *psz_name)
 }
 
 #include "command/continue.h"
-#include "command/down.h"
 #include "command/edit.h"
 #include "command/expand.h"
-#include "command/finish.h"
-#include "command/frame.h"
 #include "command/load.h"
 #include "command/next.h"
-#include "command/list.h"
 #include "command/print.h"
 #include "command/pwd.h"
 #include "command/quit.h"
@@ -203,7 +199,6 @@ find_command (const char *psz_name)
 #include "command/source.h"
 #include "command/step.h"
 #include "command/target.h"
-#include "command/up.h"
 #include "command/where.h"
 #include "command/write.h"
 
@@ -223,8 +218,8 @@ find_command (const char *psz_name)
 #include "command/help/help.h"
 #include "command/help/info.h"
 #include "command/help/load.h"
-#include "command/help/next.h"
 #include "command/help/list.h"
+#include "command/help/next.h"
 #include "command/help/print.h"
 #include "command/help/pwd.h"
 #include "command/help/quit.h"
@@ -271,11 +266,47 @@ dbg_cmd_delete_init(unsigned int c)
 }
 
 static void
+dbg_cmd_down_init(unsigned int c)
+{
+  short_command[c].func = &dbg_cmd_down;
+  short_command[c].use  = _("down [*amount]");
+}
+
+static void
+dbg_cmd_finish_init(unsigned int c)
+{
+  short_command[c].func = &dbg_cmd_finish;
+  short_command[c].use  = _("finish [*amount*]");
+}
+
+static void
+dbg_cmd_frame_init(unsigned int c)
+{
+  short_command[c].func = &dbg_cmd_frame;
+  short_command[c].use  = _("frame *n*");
+}
+
+static void
+dbg_cmd_list_init(unsigned int c)
+{
+  short_command[c].func = &dbg_cmd_list;
+  short_command[c].use = _("list [*target*|*line-number*]");
+}
+
+static void
 dbg_cmd_info_init(unsigned int c)
 {
   short_command[c].func = &dbg_cmd_info;
   short_command[c].use = _("info [*subcommand*]");
 }
+
+static void
+dbg_cmd_up_init(unsigned int c)
+{
+  short_command[c].func = &dbg_cmd_up;
+  short_command[c].use  = _("up [*amount*]");
+}
+
 
 #define DBG_CMD_INIT(CMD, LETTER, NEEDS_RUNNING)        \
   dbg_cmd_ ## CMD ## _init(LETTER);                     \

--- a/libdebugger/cmd.c
+++ b/libdebugger/cmd.c
@@ -182,7 +182,6 @@ find_command (const char *psz_name)
 }
 
 #include "command/continue.h"
-#include "command/delete.h"
 #include "command/down.h"
 #include "command/edit.h"
 #include "command/expand.h"
@@ -262,6 +261,13 @@ dbg_cmd_comment_init(unsigned int c)
 {
   short_command[c].func = &dbg_cmd_comment;
   short_command[c].use  = _("comment *text*");
+}
+
+static void
+dbg_cmd_delete_init(unsigned int c)
+{
+  short_command[c].func = &dbg_cmd_delete;
+  short_command[c].use  = _("delete *breakpoint-numbers*...");
 }
 
 static void

--- a/libdebugger/cmd.c
+++ b/libdebugger/cmd.c
@@ -181,7 +181,6 @@ find_command (const char *psz_name)
   return ((short_cmd_t *)NULL);
 }
 
-#include "command/break.h"
 #include "command/chdir.h"
 #include "command/comment.h"
 #include "command/continue.h"
@@ -245,6 +244,15 @@ find_command (const char *psz_name)
 #include "command/help/up.h"
 #include "command/help/where.h"
 #include "command/help/write.h"
+
+/* FIXME this can be folded into the below macro */
+static void
+dbg_cmd_break_init(unsigned int c)
+{
+  short_command[c].func = &dbg_cmd_break;
+  short_command[c].use  = _("break [TARGET|LINENUM] [all|run|prereq|end]*");
+}
+
 
 
 #define DBG_CMD_INIT(CMD, LETTER, NEEDS_RUNNING)        \

--- a/libdebugger/cmd.c
+++ b/libdebugger/cmd.c
@@ -181,8 +181,6 @@ find_command (const char *psz_name)
   return ((short_cmd_t *)NULL);
 }
 
-#include "command/chdir.h"
-#include "command/comment.h"
 #include "command/continue.h"
 #include "command/delete.h"
 #include "command/down.h"
@@ -190,7 +188,6 @@ find_command (const char *psz_name)
 #include "command/expand.h"
 #include "command/finish.h"
 #include "command/frame.h"
-#include "command/info.h"
 #include "command/load.h"
 #include "command/next.h"
 #include "command/list.h"
@@ -245,15 +242,34 @@ find_command (const char *psz_name)
 #include "command/help/where.h"
 #include "command/help/write.h"
 
-/* FIXME this can be folded into the below macro */
+/* FIXME: folded "init" routines into the macro them. */
 static void
 dbg_cmd_break_init(unsigned int c)
 {
   short_command[c].func = &dbg_cmd_break;
-  short_command[c].use  = _("break [TARGET|LINENUM] [all|run|prereq|end]*");
+  short_command[c].use  = _("break [*target*|*linenum*] [all|run|prereq|end]*");
 }
 
+static void
+dbg_cmd_chdir_init(unsigned int c)
+{
+  short_command[c].func = &dbg_cmd_chdir;
+  short_command[c].use  = _("cd DIR");
+}
 
+static void
+dbg_cmd_comment_init(unsigned int c)
+{
+  short_command[c].func = &dbg_cmd_comment;
+  short_command[c].use  = _("comment *text*");
+}
+
+static void
+dbg_cmd_info_init(unsigned int c)
+{
+  short_command[c].func = &dbg_cmd_info;
+  short_command[c].use = _("info [*subcommand*]");
+}
 
 #define DBG_CMD_INIT(CMD, LETTER, NEEDS_RUNNING)        \
   dbg_cmd_ ## CMD ## _init(LETTER);                     \

--- a/libdebugger/cmd.h
+++ b/libdebugger/cmd.h
@@ -28,6 +28,14 @@ Boston, MA 02111-1307, USA.  */
 #include "../src/buildargv.h"
 #include "../src/trace.h"
 
+/*!
+   Command-line args after the command-name part. For example in:
+   break foo
+   the below will be "foo".
+ **/
+extern char *psz_debugger_args;
+
+
 extern debug_return_t enter_debugger (target_stack_node_t *p,
 				      file_t *p_target, int errcode,
 				      debug_enter_reason_t reason);

--- a/libdebugger/command/break.c
+++ b/libdebugger/command/break.c
@@ -18,7 +18,7 @@ along with GNU Make; see the file COPYING.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.  */
 
-/** \file libdebugger/command/break.h
+/** \file libdebugger/command/break.c
  *
  *  \brief Debugger command to set a breakpoint at a target.
  *
@@ -26,7 +26,21 @@ Boston, MA 02111-1307, USA.  */
    Without argument, list all breaks.
 */
 
-static debug_return_t
+#include "../../src/makeint.h"
+#include "../../src/debug.h"
+#include "../../src/expand.h"
+#include "../../src/filedef.h"
+#include "../../src/trace.h"
+
+#include "../break.h"
+#include "../cmd.h"
+#include "../debugger.h"
+#include "../file2line.h"
+#include "../fns.h"
+#include "../msg.h"
+#include "../stack.h"
+
+extern debug_return_t
 dbg_cmd_break (char *psz_args)
 {
   if (!psz_args || !*psz_args) {
@@ -83,13 +97,6 @@ dbg_cmd_break (char *psz_args)
 
   return debug_readloop;
 };
-
-static void
-dbg_cmd_break_init(unsigned int c)
-{
-  short_command[c].func = &dbg_cmd_break;
-  short_command[c].use  = _("break [TARGET|LINENUM] [all|run|prereq|end]*");
-}
 
 /*
  * Local variables:

--- a/libdebugger/command/break.c
+++ b/libdebugger/command/break.c
@@ -20,10 +20,11 @@ Boston, MA 02111-1307, USA.  */
 
 /** \file libdebugger/command/break.c
  *
- *  \brief Debugger command to set a breakpoint at a target.
+ *  \brief Debugger `break` command.
  *
- * With a target name, set a break before  running commands of that target.
-   Without argument, list all breaks.
+ * Debugger command to set a breakpoint.
+ * With a target name, set a break before running commands of that target.
+ * Without an argument, list all breaks.
 */
 
 #include "../../src/makeint.h"

--- a/libdebugger/command/chdir.c
+++ b/libdebugger/command/chdir.c
@@ -1,3 +1,4 @@
+/* Write commands associated with a given target. */
 /*
 Copyright (C) 2011, 2020 R. Bernstein <rocky@gnu.org>
 This file is part of GNU Make (remake variant).
@@ -16,23 +17,31 @@ You should have received a copy of the GNU General Public License
 along with GNU Make; see the file COPYING.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.  */
-/* Comment line - ingore text on line. */
-static debug_return_t
-dbg_cmd_comment (char *psz_args)
+
+/** \file libdebugger/command/chdir.c
+ *
+ *  \brief Debugger `chdir` command.
+ *
+ *  Debugger command to set working directory to `dir`.
+ */
+
+#include "../../src/trace.h"
+
+extern debug_return_t
+dbg_cmd_chdir (char *psz_args)
 {
-  UNUSED_ARGUMENT(psz_args);
+  if (!psz_args || 0==strlen(psz_args)) {
+    printf(_("Argument required (new working directory).\n"));
+  } else {
+    if ( 0 != chdir(psz_args) ) {
+      printf("%s: %s\n", psz_args, strerror(1));
+    } else {
+      printf (_("Working directory %s.\n"), psz_args);
+    }
+  }
   return debug_readloop;
 }
 
-static void
-dbg_cmd_comment_init(unsigned int c)
-{
-  short_command[c].func = &dbg_cmd_comment;
-  short_command[c].use  = _("comment TEXT");
-}
-
-
-
 /*
  * Local variables:
  * eval: (c-set-style "gnu")

--- a/libdebugger/command/comment.c
+++ b/libdebugger/command/comment.c
@@ -1,6 +1,5 @@
-/* Write commands associated with a given target. */
 /*
-Copyright (C) 2011 R. Bernstein <rocky@gnu.org>
+Copyright (C) 2011, 2020 R. Bernstein <rocky@gnu.org>
 This file is part of GNU Make (remake variant).
 
 GNU Make is free software; you can redistribute it and/or modify
@@ -17,29 +16,22 @@ You should have received a copy of the GNU General Public License
 along with GNU Make; see the file COPYING.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.  */
-/* Comment line - ingore text on line. */
-static debug_return_t
-dbg_cmd_chdir (char *psz_args)
+
+/** \file libdebugger/command/comment.c
+ *
+ *  \brief Debugger comment line.
+ */
+
+#include "../../src/trace.h"
+
+extern debug_return_t
+dbg_cmd_comment (char *psz_args)
 {
-  if (!psz_args || 0==strlen(psz_args)) {
-    printf(_("Argument required (new working directory).\n"));
-  } else {
-    if ( 0 != chdir(psz_args) ) {
-      printf("%s: %s\n", psz_args, strerror(1));
-    } else {
-      printf (_("Working directory %s.\n"), psz_args);
-    }
-  }
+  UNUSED_ARGUMENT(psz_args);
   return debug_readloop;
 }
 
-static void
-dbg_cmd_chdir_init(unsigned int c)
-{
-  short_command[c].func = &dbg_cmd_chdir;
-  short_command[c].use  = _("cd DIR");
-}
-
+
 /*
  * Local variables:
  * eval: (c-set-style "gnu")

--- a/libdebugger/command/delete.c
+++ b/libdebugger/command/delete.c
@@ -25,7 +25,12 @@ Boston, MA 02111-1307, USA.  */
  *  in between. To delete all breakpoints, give no arguments.
  */
 
-static debug_return_t
+#include "../../src/trace.h"
+#include "../break.h"
+#include "../fns.h"
+#include "../msg.h"
+
+extern debug_return_t
 dbg_cmd_delete(char *psz_args)
 {
   int i_brkpt;
@@ -50,13 +55,6 @@ dbg_cmd_delete(char *psz_args)
   }
 
   return debug_readloop;
-}
-
-static void
-dbg_cmd_delete_init(unsigned int c)
-{
-  short_command[c].func = &dbg_cmd_delete;
-  short_command[c].use  = _("delete *breakpoint-numbers*...");
 }
 
 /*

--- a/libdebugger/command/delete.h
+++ b/libdebugger/command/delete.h
@@ -16,10 +16,14 @@ You should have received a copy of the GNU General Public License
 along with GNU Make; see the file COPYING.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.  */
-/*
-   Delete some breakpoints. Arguments are breakpoint numbers with spaces
-   in between."To delete all breakpoints, give no argument.
-*/
+
+/** \file libdebugger/command/delete.h
+ *
+ *  \brief Debugger `delete` command
+ *
+ *  Delete some breakpoints. Arguments are breakpoint numbers with spaces
+ *  in between. To delete all breakpoints, give no arguments.
+ */
 
 static debug_return_t
 dbg_cmd_delete(char *psz_args)
@@ -52,7 +56,7 @@ static void
 dbg_cmd_delete_init(unsigned int c)
 {
   short_command[c].func = &dbg_cmd_delete;
-  short_command[c].use  = _("delete BREAKPOINT_NUMBERS...");
+  short_command[c].use  = _("delete *breakpoint-numbers*...");
 }
 
 /*

--- a/libdebugger/command/down.c
+++ b/libdebugger/command/down.c
@@ -1,4 +1,4 @@
-/** Move reported target frame position to absolute position psz_frame. */
+/** Move reported target frame postition down by psz_amount. */
 /*
 Copyright (C) 2011, 2020 R. Bernstein <rocky@gnu.org>
 This file is part of GNU Make (remake variant).
@@ -17,28 +17,30 @@ You should have received a copy of the GNU General Public License
 along with GNU Make; see the file COPYING.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.  */
-debug_return_t
-dbg_cmd_frame(char *psz_frame)
-{
-  int i_frame;
 
-  if (!psz_frame || !*psz_frame) {
-    return debug_readloop;
-  } else {
-    if (!get_int(psz_frame, &i_frame, true))
+/** \file libdebugger/command/down.c
+ *
+ *  \brief Debugger "down" command
+ */
+
+
+#include "../../src/trace.h"
+#include "../fns.h"
+#include "../stack.h"
+
+debug_return_t
+dbg_cmd_down(char *psz_amount)
+{
+  int i_amount = 1;
+
+  if (!psz_amount || !*psz_amount) {
+    i_amount = 1;
+  } else if (!get_int(psz_amount, &i_amount, true)) {
       return debug_readloop;
   }
-  return dbg_adjust_frame(i_frame, true);
+  return dbg_adjust_frame(-i_amount, false);
 }
 
-static void
-dbg_cmd_frame_init(unsigned int c)
-{
-  short_command[c].func = &dbg_cmd_frame;
-  short_command[c].use  = _("frame N");
-}
-
-
 /*
  * Local variables:
  * eval: (c-set-style "gnu")

--- a/libdebugger/command/finish.c
+++ b/libdebugger/command/finish.c
@@ -1,4 +1,3 @@
-/* Terminate execution. */
 /*
 Copyright (C) 2004-2005, 2007-2009, 2011, 2015, 2020 R. Bernstein
 <rocky@gnu.org>
@@ -18,7 +17,19 @@ You should have received a copy of the GNU General Public License
 along with GNU Make; see the file COPYING.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.  */
-static debug_return_t
+
+/** \file libdebugger/command/finish.c
+ *
+ *  \brief Debugger "step out" command
+ */
+
+#include "../../src/trace.h"
+#include "../../src/variable.h"
+#include "../stack.h"
+#include "../cmd.h"
+#include "../fns.h"
+
+extern debug_return_t
 dbg_cmd_finish(char *psz_amount)
 {
   target_stack_node_t *p=p_stack;
@@ -53,13 +64,6 @@ dbg_cmd_finish(char *psz_amount)
   }
 
   return debug_readloop;
-}
-
-static void
-dbg_cmd_finish_init(unsigned int c)
-{
-  short_command[c].func = &dbg_cmd_finish;
-  short_command[c].use  = _("finish [AMOUNT]");
 }
 
 

--- a/libdebugger/command/frame.c
+++ b/libdebugger/command/frame.c
@@ -1,4 +1,4 @@
-/** Move reported target frame postition down by psz_amount. */
+/** Move reported target frame position to absolute position psz_frame. */
 /*
 Copyright (C) 2011, 2020 R. Bernstein <rocky@gnu.org>
 This file is part of GNU Make (remake variant).
@@ -18,26 +18,25 @@ along with GNU Make; see the file COPYING.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.  */
 
-debug_return_t
-dbg_cmd_frame_down(char *psz_amount)
-{
-  int i_amount = 1;
+#include "../../src/trace.h"
+#include "../fns.h"
+#include "../stack.h"
 
-  if (!psz_amount || !*psz_amount) {
-    i_amount = 1;
-  } else if (!get_int(psz_amount, &i_amount, true)) {
+debug_return_t
+dbg_cmd_frame(char *psz_frame)
+{
+  int i_frame;
+
+  if (!psz_frame || !*psz_frame) {
+    return debug_readloop;
+  } else {
+    if (!get_int(psz_frame, &i_frame, true))
       return debug_readloop;
   }
-  return dbg_adjust_frame(-i_amount, false);
+  return dbg_adjust_frame(i_frame, true);
 }
 
-static void
-dbg_cmd_down_init(unsigned int c)
-{
-  short_command[c].func = &dbg_cmd_frame_down;
-  short_command[c].use  = _("down [AMOUNT]");
-}
-
+
 /*
  * Local variables:
  * eval: (c-set-style "gnu")

--- a/libdebugger/command/help/chdir.h
+++ b/libdebugger/command/help/chdir.h
@@ -5,7 +5,7 @@
  */
 
 #define chdir_HELP_TEXT \
-  "Set the working directory to DIR.\n"					\
+  "Set the working directory to `dir`.\n"					\
   "\n"									\
   "Changing this changes will the working directory in any subsequent\n" \
   "build commands that are invoked.\n"					\

--- a/libdebugger/command/help/info.h
+++ b/libdebugger/command/help/info.h
@@ -4,5 +4,5 @@
  *
  */
 #define info_HELP_TEXT							\
-  "Show program information regarding SUBCOMMAND.\n"			\
-  "If SUBCOMMAND is not specified, give list of `info` subcommands."
+  "Show program information regarding *subcommand*.\n"			\
+  "If *subcommand* is not specified, give list of `info` subcommands."

--- a/libdebugger/command/info.c
+++ b/libdebugger/command/info.c
@@ -17,9 +17,11 @@ along with GNU Make; see the file COPYING.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.  */
 
-/** \file libdebugger/command/info.h
+/** \file libdebugger/command/info.c
  *
- *  \brief Debugger command to get various pieces of information about program being debugged.
+ *  \brief Debugger `info` command
+ *
+ *  command to get various pieces of information about program being debugged.
 */
 
 #include "../../src/commands.h"
@@ -30,6 +32,8 @@ Boston, MA 02111-1307, USA.  */
 #include "../../src/rule.h"
 #include "../../src/debug.h"
 #include "../../src/vpath.h"
+#include "../break.h"
+#include "../fns.h"
 #include "../info.h"
 #include "../msg.h"
 #include "../stack.h"
@@ -401,16 +405,6 @@ dbg_cmd_info(char *psz_args)
   }
 
   return debug_readloop;
-}
-
-static void
-dbg_cmd_info_init(unsigned int c)
-{
-  short_command[c].func = &dbg_cmd_info;
-  short_command[c].use = _("info [SUBCOMMAND]");
-  short_command[c].doc =
-    _("Show program information regarding SUBCOMMAND.\n"
-      "If SUBCOMMAND is not specified, give list of \"info\" subcommands.");
 }
 
 /*

--- a/libdebugger/command/info.h
+++ b/libdebugger/command/info.h
@@ -22,7 +22,7 @@ Boston, MA 02111-1307, USA.  */
  *  \brief Debugger command to get various pieces of information about program being debugged.
 */
 
-
+#include "../../src/commands.h"
 #include "../../src/file.h"
 #include "../../src/implicit.h"
 #include "../../src/print.h"

--- a/libdebugger/command/list.c
+++ b/libdebugger/command/list.c
@@ -23,8 +23,16 @@ Boston, MA 02111-1307, USA.  */
  *  \brief Debugger command to list Makefile target information
  */
 
+#include "../../src/trace.h"
+#include "../../src/print.h"
+#include "../file2line.h"
+#include "../cmd.h"
+#include "../fns.h"
+#include "../msg.h"
+#include "../stack.h"
+
 #define DEPENDS_COMMANDS " depends commands"
-static debug_return_t
+extern debug_return_t
 dbg_cmd_list(char *psz_arg)
 {
   const char *psz_target = NULL;
@@ -84,13 +92,6 @@ dbg_cmd_list(char *psz_arg)
   target_cmd = CALLOC(char, strlen(psz_target) + 1 + strlen(DEPENDS_COMMANDS));
   sprintf(target_cmd, "%s%s", psz_target, DEPENDS_COMMANDS);
   return dbg_cmd_target(target_cmd);
-}
-
-static void
-dbg_cmd_list_init(unsigned int c)
-{
-  short_command[c].func = &dbg_cmd_list;
-  short_command[c].use = _("list [TARGET|LINE-NUMBER]");
 }
 
 

--- a/libdebugger/command/set.h
+++ b/libdebugger/command/set.h
@@ -19,7 +19,9 @@ Boston, MA 02111-1307, USA.  */
 
 /** \file libdebugger/command/set.h
  *
- *  \brief Debugger command to change various debugger and Makefile settings and values.
+ *  \brief debugger `set` command.
+ *
+ *  Debugger command to change various debugger and Makefile settings and values.
  */
 
 /* Documentation for help set, and help set xxx. Note the format has
@@ -29,6 +31,8 @@ Boston, MA 02111-1307, USA.  */
    (or "is on").
 */
 
+#include "../../src/commands.h"
+#include "../../src/main.h"
 #include "../subcmd.h"
 
 subcommand_var_info_t set_subcommands[] = {

--- a/libdebugger/command/up.c
+++ b/libdebugger/command/up.c
@@ -18,6 +18,16 @@ along with GNU Make; see the file COPYING.  If not, write to
 the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 Boston, MA 02111-1307, USA.  */
 
+/** \file libdebugger/command/up.c
+ *
+ *  \brief Debugger "up" command
+ */
+
+
+#include "../../src/trace.h"
+#include "../fns.h"
+#include "../stack.h"
+
 debug_return_t
 dbg_cmd_up (char *psz_amount)
 {
@@ -31,14 +41,6 @@ dbg_cmd_up (char *psz_amount)
   }
   return dbg_adjust_frame(i_amount, false);
 }
-
-static void
-dbg_cmd_up_init(unsigned int c)
-{
-  short_command[c].func = &dbg_cmd_up;
-  short_command[c].use  = _("up [AMOUNT]");
-}
-
 
 
 /*

--- a/libdebugger/commands.h
+++ b/libdebugger/commands.h
@@ -1,0 +1,27 @@
+/*
+Copyright (C) 2004-2005, 2007-2009, 2011, 2020 R. Bernstein
+<rocky@gnu.org>
+This file is part of GNU Make (remake variant).
+
+GNU Make is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+GNU Make is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GNU Make; see the file COPYING.  If not, write to
+the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+Boston, MA 02111-1307, USA.  */
+
+/** \file libdebugger/commands.h
+ *
+ *  \brief Header with all debugger command functions.
+ *
+*/
+
+extern debug_return_t dbg_cmd_break (char *psz_args);

--- a/libdebugger/commands.h
+++ b/libdebugger/commands.h
@@ -27,3 +27,4 @@ Boston, MA 02111-1307, USA.  */
 extern debug_return_t dbg_cmd_break (char *psz_args);
 extern debug_return_t dbg_cmd_chdir (char *psz_args);
 extern debug_return_t dbg_cmd_comment (char *psz_args);
+extern debug_return_t dbg_cmd_delete(char *psz_args);

--- a/libdebugger/commands.h
+++ b/libdebugger/commands.h
@@ -25,3 +25,5 @@ Boston, MA 02111-1307, USA.  */
 */
 
 extern debug_return_t dbg_cmd_break (char *psz_args);
+extern debug_return_t dbg_cmd_chdir (char *psz_args);
+extern debug_return_t dbg_cmd_comment (char *psz_args);

--- a/libdebugger/commands.h
+++ b/libdebugger/commands.h
@@ -28,3 +28,8 @@ extern debug_return_t dbg_cmd_break (char *psz_args);
 extern debug_return_t dbg_cmd_chdir (char *psz_args);
 extern debug_return_t dbg_cmd_comment (char *psz_args);
 extern debug_return_t dbg_cmd_delete(char *psz_args);
+extern debug_return_t dbg_cmd_down(char *psz_args);
+extern debug_return_t dbg_cmd_finish(char *psz_args);
+extern debug_return_t dbg_cmd_frame(char *psz_args);
+extern debug_return_t dbg_cmd_list(char *psz_args);
+extern debug_return_t dbg_cmd_up(char *psz_args);

--- a/libdebugger/info.h
+++ b/libdebugger/info.h
@@ -31,4 +31,7 @@ Boston, MA 02111-1307, USA.  */
 extern debug_enter_reason_t last_stop_reason;
 extern const char *WARRANTY;
 
+#include "subcmd.h"
+extern subcommand_var_info_t info_subcommands[];
+
 #endif /* DBG_INFO_H*/

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -18,9 +18,9 @@
 libdebugger/break.c
 libdebugger/cmd.c
 libdebugger/command/chdir.c
+libdebugger/command/delete.c
 libdebugger/command/info.c
 libdebugger/command/continue.h
-libdebugger/command/delete.h
 libdebugger/command/down.h
 libdebugger/command/edit.h
 libdebugger/command/eval.h

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -17,8 +17,8 @@
 
 libdebugger/break.c
 libdebugger/cmd.c
-libdebugger/command/chdir.h
-libdebugger/command/comment.h
+libdebugger/command/chdir.c
+libdebugger/command/info.c
 libdebugger/command/continue.h
 libdebugger/command/delete.h
 libdebugger/command/down.h
@@ -28,7 +28,6 @@ libdebugger/command/expand.h
 libdebugger/command/finish.h
 libdebugger/command/frame.h
 libdebugger/command/help.h
-libdebugger/command/info.h
 libdebugger/command/list.h
 libdebugger/command/load.h
 libdebugger/command/next.h

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -17,7 +17,6 @@
 
 libdebugger/break.c
 libdebugger/cmd.c
-libdebugger/command/break.h
 libdebugger/command/chdir.h
 libdebugger/command/comment.h
 libdebugger/command/continue.h

--- a/src/make.h
+++ b/src/make.h
@@ -177,15 +177,6 @@ unsigned int get_path_max (void);
 # define S_ISDIR(mode)  (((mode) & S_IFMT) == S_IFDIR)
 #endif
 
-#ifdef VMS
-# include <types.h>
-# include <unixlib.h>
-# include <unixio.h>
-# include <perror.h>
-/* Needed to use alloca on VMS.  */
-# include <builtins.h>
-#endif
-
 #ifndef __attribute__
 /* This feature is available in gcc versions 2.5 and later.  */
 # if __GNUC__ < 2 || (__GNUC__ == 2 && __GNUC_MINOR__ < 5) || __STRICT_ANSI__


### PR DESCRIPTION
This is an example of what I was talking about with respect to creating commands in its own object file rather than having it combined as a (fat) static inside cmd.c. 

