### PR TITLE
Readme.md: fix kcachegrind url

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ Example showing `--show-parent` (short option `-c`) feature:
 
 ![--show-parent](screenshots/remake-search-parent.gif)
 
-Example showing `--profiling` output (displayed via [KCachegrind](https://kcachegrind.github.io/html/Home.htmlkcachegrind)):
+Example showing `--profiling` output (displayed via [KCachegrind](https://kcachegrind.github.io/html/Home.html)):
 
 ![--profile](screenshots/remake-profiled2.png)


### PR DESCRIPTION
This is just a ~6-letter fix, I won't mind if you just commit it yourself and push it as a fix at some point a bit later.