### PR TITLE
Handle debugger-originated variables in 'info variables'

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -1709,6 +1709,9 @@ print_variable (const void *item, void *arg)
     case o_override:
       origin = _("'override' directive");
       break;
+    case o_debugger:
+      origin = _("debugger");
+      break;
     case o_invalid:
     default:
       abort ();


### PR DESCRIPTION
Just a little bug fix. I hit the abort case doing `info var`:
```
Program received signal SIGABRT, Aborted.
0x00007ffff7be2615 in raise () from /usr/lib/libc.so.6
(gdb) bt
#0  0x00007ffff7be2615 in raise () from /usr/lib/libc.so.6
#1  0x00007ffff7bcb862 in abort () from /usr/lib/libc.so.6
#2  0x00005555555932bc in print_variable (item=0x5555555de100, arg=0x5555555a4905) at src/variable.c:1714
#3  0x0000555555570a98 in hash_map_arg (ht=0x5555555b99c0 <global_variable_set>, map=0x5555555931da <print_variable>, arg=0x5555555a4905) at src/hash.c:244
#4  0x000055555559381a in print_variable_set (set=0x5555555b99c0 <global_variable_set>, prefix=0x5555555a4905 "", pauto=0) at src/variable.c:1830
#5  0x00005555555938bd in print_variable_data_base () at src/variable.c:1846
#6  0x00005555555967d5 in dbg_cmd_info (psz_args=0x555555617ac5 "") at command/info.c:396
#7  0x0000555555598f3a in execute_line (psz_line=0x555555617ac2 "var") at cmd.c:160
#8  0x000055555559976e in enter_debugger (p=0x0, p_target=0x0, errcode=0, reason=DEBUG_READ_HIT) at cmd.c:385
#9  0x0000555555582c7a in eval_makefile (filename=0x5555555d32ae "private-var.mk", flags=0) at src/read.c:426
#10 0x00005555555824f7 in read_all_makefiles (makefiles=0x5555555d3270) at src/read.c:214
#11 0x000055555557aecf in main (argc=4, argv=0x7fffffffdf48, envp=0x7fffffffdf70) at src/main.c:1779
(gdb) fr 2
#2  0x00005555555932bc in print_variable (item=0x5555555de100, arg=0x5555555a4905) at src/variable.c:1714
1714          abort ();
(gdb) p *v
$2 = {name = 0x5555555de140 "MAKEFLAGS", value = 0x5555555de160 "X", fileinfo = {filenm = 0x0, lineno = 0, offset = 0}, length = 9, recursive = 0, append = 0, conditional = 0, per_target = 0, special = 0, exportable = 1, expanding = 0, private_var = 0, exp_count = 0,
  flavor = f_bogus, origin = o_debugger, export = v_export}
```

This was after doing `remake --debugger-stop=preread` and stepping once.