### PR TITLE
Add this_file, this_counter, GNUremake

### DIFF
--- a/doc/make.texi
+++ b/doc/make.texi
@@ -7652,7 +7652,7 @@ macro of the C programming language understood by GCC.
 
 @end table
 
-
+@node Conditional Functions, Foreach Function, File Name Functions, Functions
 @section Functions for Conditionals
 @findex if
 @cindex conditional expansion

--- a/doc/make.texi
+++ b/doc/make.texi
@@ -7626,9 +7626,33 @@ separators (@code{/}).  Note that, in contrast to @code{realpath}
 function, @code{abspath} does not resolve symlinks and does not require
 the file names to refer to an existing file or directory.  Use the
 @code{wildcard} function to test for existence.
+
+@item $(this_line)
+@findex this_line
+@cindex this_line, function
+The invocation @code{$(this_line)} expands to the current line
+number.  It is inspired by the @code{__LINE__} magical macro of the C
+programming language.
+
+
+@item $(this_file)
+@findex this_file
+@cindex this_file, function
+The invocation @code{$(this_file)} expands to the current filename,
+e.g. to @code{Makefile}.  It is inspired by the @code{__FILE__}
+magical macro of the C programming language.
+
+
+@item $(this_counter)
+@findex this_counter
+@cindex this_counter, function
+The invocation @code{$(this_counter)} expands to a unique, incremented,
+counter (in decimal). It is inspired by the @code{__COUNTER__} magical
+macro of the C programming language understood by GCC.
+
 @end table
 
-@node Conditional Functions, Foreach Function, File Name Functions, Functions
+
 @section Functions for Conditionals
 @findex if
 @cindex conditional expansion

--- a/src/function.c
+++ b/src/function.c
@@ -1376,20 +1376,13 @@ func_value (char *o, char **argv, const char *funcname UNUSED)
 /**
   $(this_file)
 
-  Always expands to the current Makefile path.  Inspired by the __FILE__macro of C.
+  Always expands to the current Makefile path.  Inspired by the __FILE__ macro of C.
 **/
 
 static char *
-func_this_file (char *o, char **argv UNUSED, const char *funcname UNUSED)
+func_this_file (char *o, char **argv, const char *funcname UNUSED)
 {
   fprintf(stderr, "@func_this_file (%s:%d)\n", __FILE__, __LINE__);
-  if (reading_file)
-    {
-      const char*curfil = reading_file->filenm;
-      if (curfil && curfil[0]) {
-	return strdup(curfil);
-      }
-    }
   return o;
 }
 
@@ -1397,23 +1390,12 @@ func_this_file (char *o, char **argv UNUSED, const char *funcname UNUSED)
 /**
   $(this_line)
 
-  Always expands to the current line number.   Inspired by the __LINE__macro of C.
+  Always expands to the current line number.   Inspired by the __LINE__ macro of C.
 **/
 
 static char *
-func_this_line (char *o, char **argv UNUSED, const char *funcname UNUSED)
+func_this_line (char *o, char **argv, const char *funcname UNUSED)
 {
-  fprintf(stderr, "@func_this_line (%s:%d)\n", __FILE__, __LINE__);
-  if (reading_file)
-    {
-      unsigned long curlineno = reading_file->lineno;
-      if (curlineno) {
-	char linenobuf[32];
-	memset(linenobuf, 0, sizeof(linenobuf));
-	snprintf(linenobuf, sizeof(linenobuf), "%lu", curlineno);
-	return strdup(linenobuf);
-      }
-    }
   return o;
 }
 
@@ -1421,19 +1403,18 @@ func_this_line (char *o, char **argv UNUSED, const char *funcname UNUSED)
 /**
   $(this_counter)
 
-  Always expands to a unique, incremented, counter.   Inspired by the __COUNT__macro of GCC.
+  Always expands to a unique, incremented, counter.   Inspired by the __COUNTER__ macro of GCC.
 **/
 
 static char *
 func_this_counter (char *o UNUSED, char **argv UNUSED, const char *funcname UNUSED)
 {
-  static unsigned long curcounter;
-  char curcountbuf[32];
-  fprintf(stderr, "@func_this_counter (%s:%d)\n", __FILE__, __LINE__);
-  memset (curcountbuf, 0, sizeof(curcountbuf));
-  curcounter++;
-  snprintf (curcountbuf, sizeof(curcountbuf), "%lu", curcounter);
-  return strdup(curcountbuf);
+  static long counter;
+  char cntbuf[32];
+  memset (cntbuf, 0, sizeof(cntbuf));
+  counter++;
+  snprintf (cntbuf, sizeof(cntbuf), "%ld", counter);
+  return xstrdup(cntbuf);
 }
 ///// end of functions added by  <basile@starynkevitch.net>
 

--- a/src/function.c
+++ b/src/function.c
@@ -1370,6 +1370,50 @@ func_value (char *o, char **argv, const char *funcname UNUSED)
   return o;
 }
 
+///// added by <basile@starynkevitch.net>
+
+
+/**
+  $(this_file)
+
+  Always expands to the current Makefile path.  Inspired by the __FILE__macro of C.
+**/
+
+static char *
+func_this_file (char *o, char **argv, const char *funcname UNUSED)
+{
+  fprintf(stderr, "@func_this_file (%s:%d)\n", __FILE__, __LINE__);
+  return o;
+}
+
+
+/**
+  $(this_line)
+
+  Always expands to the current line number.   Inspired by the __LINE__macro of C.
+**/
+
+static char *
+func_this_line (char *o, char **argv, const char *funcname UNUSED)
+{
+  return o;
+}
+
+
+/**
+  $(this_counter)
+
+  Always expands to a unique, incremented, counter.   Inspired by the __COUNT__macro of GCC.
+**/
+
+static char *
+func_this_counter (char *o, char **argv, const char *funcname UNUSED)
+{
+  return o;
+}
+///// end of functions added by  <basile@starynkevitch.net>
+
+
 /*
   \r is replaced on UNIX as well. Is this desirable?
  */
@@ -2210,6 +2254,10 @@ static struct function_table_entry function_table_init[] =
   FT_ENTRY ("eval",          0,  1,  1,  func_eval),
   FT_ENTRY ("file",          1,  2,  1,  func_file),
   FT_ENTRY ("debugger",      0,  1,  1,  func_debugger),
+  /// three functions added by <basile@starynkevitch.net>
+  FT_ENTRY ("this_file",     0,  0,  0,  func_this_file),
+  FT_ENTRY ("this_line",     0,  0,  0,  func_this_line),
+  FT_ENTRY ("this_counter",  0,  0,  0,  func_this_counter),
 #ifdef EXPERIMENTAL
   FT_ENTRY ("eq",            2,  2,  1,  func_eq),
   FT_ENTRY ("not",           0,  1,  1,  func_not),
@@ -2236,7 +2284,10 @@ expand_builtin_function (char *o, int argc, char **argv,
      but so far no internal ones do, so just test it for all functions here
      rather than in each one.  We can change it later if necessary.  */
 
-  if (!argc && !entry_p->alloc_fn)
+  if (!argc
+      /// the functions named this_* by <basile@starynkevitch.net> take no arguments...
+      && strncmp(entry_p->name, "this", sizeof("this")-1)
+      && !entry_p->alloc_fn)
     return o;
 
   if (!entry_p->fptr.func_ptr)

--- a/src/function.c
+++ b/src/function.c
@@ -1380,10 +1380,13 @@ func_value (char *o, char **argv, const char *funcname UNUSED)
 **/
 
 static char *
-func_this_file (char *o, char **argv, const char *funcname UNUSED)
+func_this_file (char *o UNUSED, char **argv UNUSED, const char *funcname UNUSED)
 {
-  fprintf(stderr, "@func_this_file (%s:%d)\n", __FILE__, __LINE__);
-  return o;
+  if (reading_file) {
+    return xstrdup(reading_file->filenm);
+  }
+  else
+    return xstrdup("?");
 }
 
 
@@ -1394,9 +1397,16 @@ func_this_file (char *o, char **argv, const char *funcname UNUSED)
 **/
 
 static char *
-func_this_line (char *o, char **argv, const char *funcname UNUSED)
+func_this_line (char *o UNUSED, char **argv UNUSED, const char *funcname UNUSED)
 {
-  return o;
+  if (reading_file) {
+    char linumbuf[32];
+    memset (linumbuf, 0, sizeof(linumbuf));
+    snprintf(linumbuf, sizeof(linumbuf),  "%lu", reading_file->lineno);
+    return xstrdup(linumbuf);
+  }
+  else
+    return xstrdup("0");
 }
 
 

--- a/src/function.c
+++ b/src/function.c
@@ -1380,14 +1380,14 @@ func_value (char *o, char **argv, const char *funcname UNUSED)
 **/
 
 static char *
-func_this_file (char *o, char **argv, const char *funcname UNUSED)
+func_this_file (char *o, char **argv UNUSED, const char *funcname UNUSED)
 {
   fprintf(stderr, "@func_this_file (%s:%d)\n", __FILE__, __LINE__);
   if (reading_file)
     {
       const char*curfil = reading_file->filenm;
       if (curfil && curfil[0]) {
-#warning should func_this_file return curfil or strdup(curfil) here?
+	return strdup(curfil);
       }
     }
   return o;
@@ -1401,8 +1401,9 @@ func_this_file (char *o, char **argv, const char *funcname UNUSED)
 **/
 
 static char *
-func_this_line (char *o, char **argv, const char *funcname UNUSED)
+func_this_line (char *o, char **argv UNUSED, const char *funcname UNUSED)
 {
+  fprintf(stderr, "@func_this_line (%s:%d)\n", __FILE__, __LINE__);
   if (reading_file)
     {
       unsigned long curlineno = reading_file->lineno;
@@ -1410,7 +1411,7 @@ func_this_line (char *o, char **argv, const char *funcname UNUSED)
 	char linenobuf[32];
 	memset(linenobuf, 0, sizeof(linenobuf));
 	snprintf(linenobuf, sizeof(linenobuf), "%lu", curlineno);
-#warning should func_this_line return strdup(linenobuf) here?
+	return strdup(linenobuf);
       }
     }
   return o;
@@ -1424,15 +1425,15 @@ func_this_line (char *o, char **argv, const char *funcname UNUSED)
 **/
 
 static char *
-func_this_counter (char *o, char **argv, const char *funcname UNUSED)
+func_this_counter (char *o UNUSED, char **argv UNUSED, const char *funcname UNUSED)
 {
   static unsigned long curcounter;
-  curcounter++;
   char curcountbuf[32];
+  fprintf(stderr, "@func_this_counter (%s:%d)\n", __FILE__, __LINE__);
   memset (curcountbuf, 0, sizeof(curcountbuf));
+  curcounter++;
   snprintf (curcountbuf, sizeof(curcountbuf), "%lu", curcounter);
-#warning should func_this_counter return strdup(curcountbuf) here?
-  return o;
+  return strdup(curcountbuf);
 }
 ///// end of functions added by  <basile@starynkevitch.net>
 

--- a/src/function.c
+++ b/src/function.c
@@ -1383,6 +1383,13 @@ static char *
 func_this_file (char *o, char **argv, const char *funcname UNUSED)
 {
   fprintf(stderr, "@func_this_file (%s:%d)\n", __FILE__, __LINE__);
+  if (reading_file)
+    {
+      const char*curfil = reading_file->filenm;
+      if (curfil && curfil[0]) {
+#warning should func_this_file return curfil or strdup(curfil) here?
+      }
+    }
   return o;
 }
 
@@ -1396,6 +1403,16 @@ func_this_file (char *o, char **argv, const char *funcname UNUSED)
 static char *
 func_this_line (char *o, char **argv, const char *funcname UNUSED)
 {
+  if (reading_file)
+    {
+      unsigned long curlineno = reading_file->lineno;
+      if (curlineno) {
+	char linenobuf[32];
+	memset(linenobuf, 0, sizeof(linenobuf));
+	snprintf(linenobuf, sizeof(linenobuf), "%lu", curlineno);
+#warning should func_this_line return strdup(linenobuf) here?
+      }
+    }
   return o;
 }
 
@@ -1409,6 +1426,12 @@ func_this_line (char *o, char **argv, const char *funcname UNUSED)
 static char *
 func_this_counter (char *o, char **argv, const char *funcname UNUSED)
 {
+  static unsigned long curcounter;
+  curcounter++;
+  char curcountbuf[32];
+  memset (curcountbuf, 0, sizeof(curcountbuf));
+  snprintf (curcountbuf, sizeof(curcountbuf), "%lu", curcounter);
+#warning should func_this_counter return strdup(curcountbuf) here?
   return o;
 }
 ///// end of functions added by  <basile@starynkevitch.net>

--- a/src/read.c
+++ b/src/read.c
@@ -228,7 +228,7 @@ read_all_makefiles (const char **makefiles)
     {
       PATH_VAR (current_directory);
       static const char *default_makefiles[] =
-        { "GNUmakefile", "makefile", "Makefile", 0 };
+        { "GNUremakefile", "GNUmakefile", "makefile", "Makefile", 0 };
       const char **p;
 
       while (1) {

--- a/tests/scripts/features/default_names
+++ b/tests/scripts/features/default_names
@@ -3,6 +3,13 @@
 $description = "This script tests to make sure that Make looks for
 default makefiles in the correct order (GNUmakefile,makefile,Makefile)";
 
+# Create a makefile called "GNUremakefile"
+$remakefile = "GNUremakefile";
+
+open(MAKEFILE,"> $remakefile");
+print MAKEFILE "FIRST: ; \@echo It chose GNUremakefile\n";
+close(MAKEFILE);
+
 # Create a makefile called "GNUmakefile"
 $makefile = "GNUmakefile";
 
@@ -26,6 +33,10 @@ if (! -f 'Makefile') {
     print MAKEFILE "THIRD: ; \@echo It chose Makefile\n";
     close(MAKEFILE);
 }
+
+run_make_with_options("","",&get_logfile);
+compare_output("It chose GNUremakefile\n",&get_logfile(1));
+unlink($remakefile);
 
 run_make_with_options("","",&get_logfile);
 compare_output("It chose GNUmakefile\n",&get_logfile(1));


### PR DESCRIPTION
@bstarynk this addresses the build failure and has a test for GNUremakefile

However I don't see that the `this_` functions work. 

For example for this Makefile

```.PHONY: x
B = c d $(this_file) $(this_line) $(this_counter)

x:
	@echo $(B)
```

I get: 

```
$ ../make -x -f this.Makefile
Reading makefiles...
Updating makefiles...
Updating goal targets...
 File 'x' does not exist.
Must remake target 'x'.
this.Makefile:5: target 'x' does not exist
##>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
echo c d   
##<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
c d
Successfully remade target file 'x'.
```

If the `this` functions work for you, maybe you can give an example simiilar to the above? 
