### PR TITLE
Support outputting profiling information as json

### DIFF
--- a/doc/make.1
+++ b/doc/make.1
@@ -139,6 +139,18 @@ have the format specified in the
 manual.
 
 .TP 0.5i
+.B \-\-profile\-directory=[PATH]
+Specifies the
+.I PATH
+that profiling files should be written to. Must exist
+before running
+.IR make .
+It is assumed to be a relative path to the initial directory
+where
+.I make
+is called, unless it begins with a ~ or /.
+
+.TP 0.5i
 .BR "\-\-targets"
 Print a list of explicitly-named targets found in read-in makefiles.
 

--- a/doc/make.1
+++ b/doc/make.1
@@ -118,23 +118,25 @@ Go into the debugger on an error. This is the
 Same as options: \-\-debugger \-\-debugger\-stop=error
 
 .TP 0.5i
-\fB\-P\fR, \fB\-\-profile\fR
-Creates profile output in both json and callgrind format.
-Callgrind output can be used with kcachegrind, callgrind_annotate,
-or gprof2dot to analyze data. You can get not only timings, but
-a graph of the target dependencies checked
-
-.TP 0.5i
-\fB\-P\fR, \fB\-\-profile\-callgrind\fR
-Creates callgrind profile output.
-Callgrind output can be used with kcachegrind, callgrind_annotate,
-or gprof2dot to analyze data. You can get not only timings, but
-a graph of the target dependencies checked
-
-.TP 0.5i
-\fB\-P\fR, \fB\-\-profile\-json\fR
-Creates json profile output.
-Json output can be used with custom tools to analyze data.
+.B \-P, " \-\-profile [=TYPE]
+Enables timing and dependency profiling output using the specified
+.I TYPE
+for formatting.
+.I TYPE
+can be either 
+.I callgrind
+or
+.IR json .
+If omitted, it defaults to
+.IR callgrind .
+Files generated using
+.I callgrind
+can be analyzed with kcachegrind, callgrind_annotate, or
+gprof2dot. Files generated with
+.I json
+have the format specified in the
+.I info
+manual.
 
 .TP 0.5i
 .BR "\-\-targets"

--- a/doc/remake.texi
+++ b/doc/remake.texi
@@ -1068,28 +1068,141 @@ are a number of handy extensions to @value{MAKE} that we list here.
 @end menu
 
 @node Profiling and Visualization
-@section Getting data on where build time is spent
-
-If you want to know where most of the time goes in building your system with Makefiles,
-there is a @code{--profile} option which times the targets.
+@section Profiling build execution timing and dependencies
 @cindex @code{--profile}
-
+@cindex profiling
 
 @smallexample
-  $ remake --profile # target...
+  $ remake --profile[=callgrind|json] # target...
 @end smallexample
 
-@value{REMAKE} outputs callgrind profile format data
+The @code{--profile} option enables dependency and timing output
+from build execution. The data can be used to determine where your
+build system spends it's time. By default, the @code{--profile}
+option outputs profiling data in the callgrind format
 @footnote{@url{http://valgrind.org/docs/manual/cl-format.html}} which
 can be used with
 @code{kcachegrind}@footnote{http://kcachegrind.sourceforge.net/html/Home.html}
 or other
 tools@footnote{@url{https://github.com/icefox/callgrind_tools},
 @url{https://github.com/zenkj/callgrind2dot}} that work with this
-format. that work with this format.
+format. Each recursive call to @value{REMAKE} generates its own
+output in the starting directory named @code{callgrind.out.<pid>}
+where @code{pid} is the PID of the @value{REMAKE} process.
 
-You can get not only timings, but a graph of the target dependencies
-checked.
+@subsection JSON-formatted profiling data
+@cindex json
+
+The @code{--profile} option also accepts a @code{json} flag that
+will output profiling data in json-formatted files. With the following
+formatting:
+
+@example
+ @{
+     "version":"1.0.0",
+     "pid":1234,
+     "parent":@{
+         "pid":1230,
+         "target":"target-name"
+     @},
+     "jobs": 8,
+     "server": true,
+     "creator":"remake"
+     "argv":[
+         "arg0",
+         "arg1",
+         "arg2"
+     ],
+     "directory":"path/to/working/dir",
+     "status":"Normal program termination",
+     "start":1235.6789,
+     "end":1240.0123,
+     "resolution":1000,
+     "entry":[
+         "all",
+         "other"
+     ],
+     "targets":[
+         @{
+             "name":"all",
+             "file":"path/to/file/with/target",
+             "line":100,
+             "start":123.123,
+             "deps":null,
+             "recipe":124.0,
+             "end":124.124,
+             "depends":[
+                 "dependent",
+                 "target0",
+                 "target1",
+                 "target2"
+             ]
+         @}
+     ]
+ @}
+@end example
+
+@subsubsection Top-level field definitions
+@table @code
+@item version
+The @code{version} field specifies the version of build.json file.
+@item pid
+The PID of the @value{REMAKE} execution that created this file
+@item parent.pid
+If present, this PID of the @value{REMAKE} process that recursively called the
+current @value{REMAKE} process
+@item parent.target
+If present, the name of the target the parent @value{REMAKE} process that
+recusively called the current @value{REMAKE} process.
+@item jobs
+If present, either @code{unlimited} when parallel jobs were not restricted. Or
+an integer value reprenting the maximum number of available jobs.
+@item server
+True if connected to a jobserver
+@item creator
+A string representing the version of @value{REMAKE} that generated this file
+@item argv
+An array of strings that represent the command used to start @value{REMAKE}
+@item directory
+Path to the starting directory, generally the path current directory or the value
+passed to @value{REMAKE} with @code{-C path/to/subdir}
+@item status
+String representing what caused @value{REMAKE} to exit
+@item start
+Timestamp in seconds representing when @value{REMAKE} started
+@item end
+Timestamp in seconds representing when @value{REMAKE} ended
+@item resolution
+Number of nanoseconds specifying the minimum resolution of timestamps
+in the output
+@item entry
+An array of targets that were requested to be built.
+@item targets
+An array of target specifications
+@end table
+
+@subsubsection Target field definitions
+@table @code
+@item name
+Name of the target
+@item file
+Path to the file that contains the target definition relative to the top-level
+@code{directory} field
+@item line
+Line number of the @code{name} target in the @code{file} field
+@item start
+Timestamp when the target was first considered by @value{REMAKE}
+@item deps
+Timestamp when @value{REMAKE} marked the target as waiting on dependencies.
+Or @code{null} if it was not marked as waiting.
+@item recipe
+Timestamp when the recipe for the target began execution. Or @code{null} if
+the recipe did not need to execute.
+@item end
+Timestamp when the target was considered complete
+@item depends
+Array of target names that this target depended on.
+@end table
 
 @node Comments
 @section Listing and Documenting Makefile Targets

--- a/doc/remake.texi
+++ b/doc/remake.texi
@@ -1090,6 +1090,13 @@ format. Each recursive call to @value{REMAKE} generates its own
 output in the starting directory named @code{callgrind.out.<pid>}
 where @code{pid} is the PID of the @value{REMAKE} process.
 
+By default, profiling data is written in the same directory where
+@value{REMAKE} is executed. This includes recursive calls. The
+@code{--profile-directory} argument can be used to specify a
+single directory for all profiling data. This is taken to
+be relative to the initial invocation of @value{REMAKE} unless
+the path begins with ~ or /.
+
 @subsection JSON-formatted profiling data
 @cindex json
 

--- a/src/callgrind_format.c
+++ b/src/callgrind_format.c
@@ -24,10 +24,10 @@ Boston, MA 02111-1307, USA.  */
 #include "callgrind_format.h"
 
 #define CALLGRIND_FILE_PREFIX "callgrind.out."
-#define CALLGRIND_FILE_TEMPLATE CALLGRIND_FILE_PREFIX "%d"
+#define CALLGRIND_FILE_TEMPLATE "%s/" CALLGRIND_FILE_PREFIX "%d"
 
 /* + 10 is more than enough since 2**64 ~= 10**9 */
-#define CALLGRIND_FILENAME_LEN sizeof(CALLGRIND_FILE_PREFIX) + 20
+#define CALLGRIND_FILENAME_LEN (GET_PATH_MAX)
 
 #define CALLGRIND_PREAMBLE_TEMPLATE1 "version: 1\n\
 creator: %s\n"
@@ -50,7 +50,7 @@ callgrind_init(profile_context_t *ctx, const char *creator, const char *const *a
   size_t len;
   unsigned int i;
 
-  len = sprintf(callgrind_fname, CALLGRIND_FILE_TEMPLATE, ctx->pid);
+  len = sprintf(callgrind_fname, CALLGRIND_FILE_TEMPLATE, ctx->output_dir, ctx->pid);
 
   if (len >= CALLGRIND_FILENAME_LEN) {
     printf("Error in generating callgrind name\n");

--- a/src/globals.c
+++ b/src/globals.c
@@ -35,14 +35,8 @@ int print_version_flag = 0;
 /*! Nonzero means --trace and shell trace with input.  */
 int shell_trace = 0;
 
-/* Nonzero means profile calls (option --profile).  */
+/* Nonzero means profiling is enabled with specific output requested. (option --profile=callgrind|json  */
 int profile_flag = 0;
-
-/* Nonzero means output json for profiling (option --profile-json) */
-int profile_json_flag = 0;
-
-/* Nonzero means output json for profiling (option --profile-callgrind) */
-int profile_callgrind_flag = 0;
 
 /* Nonzero means look in parent directories for a Makefile if one isn't found
    in the current directory (option --search-parent).  */

--- a/src/globals.c
+++ b/src/globals.c
@@ -38,6 +38,9 @@ int shell_trace = 0;
 /* Nonzero means profiling is enabled with specific output requested. (option --profile=callgrind|json  */
 int profile_flag = 0;
 
+/* Path to directory to dump profiling data */
+const char *profile_directory;
+
 /* Nonzero means look in parent directories for a Makefile if one isn't found
    in the current directory (option --search-parent).  */
 int search_parent_flag = 0;

--- a/src/globals.h
+++ b/src/globals.h
@@ -43,6 +43,9 @@ extern int shell_trace;
 /*! Nonzero means profiling is enabled with specific output requested. (option --profile=callgrind|json)  */
 extern int profile_flag;
 
+/* Path to directory to dump profiling data */
+extern const char *profile_directory;
+
 /*! Nonzero means look in parent directories for a Makefile if one isn't found
    in the current directory (option --search-parent).  */
 extern int search_parent_flag;

--- a/src/globals.h
+++ b/src/globals.h
@@ -40,14 +40,8 @@ extern int print_version_flag;
 /*! Nonzero means --trace and shell trace with input.  */
 extern int shell_trace;
 
-/*! Nonzero means profile calls (option --profile).  */
+/*! Nonzero means profiling is enabled with specific output requested. (option --profile=callgrind|json)  */
 extern int profile_flag;
-
-/* Nonzero means output json for profiling (option --profile-json) */
-extern int profile_json_flag;
-
-/* Nonzero means output json for profiling (option --profile-callgrind) */
-extern int profile_callgrind_flag;
 
 /*! Nonzero means look in parent directories for a Makefile if one isn't found
    in the current directory (option --search-parent).  */

--- a/src/json_format.c
+++ b/src/json_format.c
@@ -160,7 +160,7 @@ static void
 dump_jobserver(FILE *fd, profile_context_t *ctx)
 {
   fprintf(fd, LVL1 "\"jobs\":%d,\n", ctx->jobs);
-  fprintf(fd, LVL1 "\"server\":%d,\n", ctx->jobserver);
+  fprintf(fd, LVL1 "\"server\":%s,\n", ctx->jobserver ? "true" : "false");
 
 }
 

--- a/src/json_format.c
+++ b/src/json_format.c
@@ -38,9 +38,9 @@ this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 #define JSON_FILE_PREFIX "build."
 #define JSON_FILE_EXT    ".json"
-#define JSON_FILE_TEMPLATE JSON_FILE_PREFIX "%d" JSON_FILE_EXT
+#define JSON_FILE_TEMPLATE "%s/" JSON_FILE_PREFIX "%d" JSON_FILE_EXT
 
-#define JSON_FILENAME_LEN (sizeof(JSON_FILE_PREFIX) + 20 + sizeof(JSON_FILE_EXT))
+#define JSON_FILENAME_LEN (GET_PATH_MAX)
 
 #define JSON_FILE_VER   "1.0.0"
 
@@ -65,7 +65,7 @@ static void dump_target(const void *item);
 static void dump_target_timestamps(FILE *fd, const profile_entry_t *p);
 static void dump_depends(FILE *fd, const profile_call_t *c);
 
-static char json_fname[JSON_FILENAME_LEN];
+static char json_fname[GET_PATH_MAX];
 static FILE *json_fd;
 static bool first_entry;
 
@@ -265,7 +265,7 @@ json_init(profile_context_t *ctx, const char *creator, const char *const *argv)
 {
   size_t len;
 
-  len = sprintf(json_fname, JSON_FILE_TEMPLATE, ctx->pid);
+  len = sprintf(json_fname, JSON_FILE_TEMPLATE, ctx->output_dir, ctx->pid);
 
   if (len >= JSON_FILENAME_LEN) {
     printf("Error in generating json name\n");

--- a/src/profile.c
+++ b/src/profile.c
@@ -109,17 +109,19 @@ profile_init(const char *creator, const char *const *argv, int jobs) {
   }
 #endif
 
-  /* If neither is set, then consider both set */
-  if (profile_callgrind_flag || !profile_json_flag) {
-    if (!callgrind_init(&ctx, creator, argv)) {
-      return false;
-    }
-  }
-
-  if (profile_json_flag || !profile_callgrind_flag) {
-    if (!json_init(&ctx, creator, argv)) {
-      return false;
-    }
+  switch (profile_flag) {
+    case PROFILE_CALLGRIND:
+      if (!callgrind_init(&ctx, creator, argv)) {
+        return false;
+      }
+      break;
+    case PROFILE_JSON:
+      if (!json_init(&ctx, creator, argv)) {
+        return false;
+      }
+      break;
+    default:
+      break;
   }
 
   hash_init(&profile_table, 1000, profile_table_entry_hash_1,
@@ -226,11 +228,14 @@ profile_close(const char *program_status, const struct goaldep *goal, bool jobse
   profile_dump_entries(print_profile_entry);
 #endif
 
-  if (profile_callgrind_flag || !profile_json_flag) {
-    callgrind_close(&ctx, program_status);
-  }
-
-  if (profile_json_flag || !profile_callgrind_flag) {
-    json_close(&ctx, program_status);
+  switch (profile_flag) {
+    case PROFILE_CALLGRIND:
+      callgrind_close(&ctx, program_status);
+      break;
+    case PROFILE_JSON:
+      json_close(&ctx, program_status);
+      break;
+    default:
+      break;
   }
 }

--- a/src/profile.c
+++ b/src/profile.c
@@ -97,6 +97,7 @@ profile_init(const char *creator, const char *const *argv, int jobs) {
 
   ctx.jobs = jobs;
   ctx.pid = getpid();
+  ctx.output_dir = profile_directory;
 
   ctx.resolution = 0;
   ctx.start = file_timestamp_now(&ctx.resolution);

--- a/src/profile.h
+++ b/src/profile.h
@@ -29,6 +29,10 @@ Boston, MA 02111-1307, USA.  */
 #include <sys/time.h>
 #include "filedef.h"
 
+#define PROFILE_DISABLED    0
+#define PROFILE_CALLGRIND   1
+#define PROFILE_JSON        2
+
 struct profile_entry;
 
 /*! \brief Node for an item in the target call stack */

--- a/src/profile.h
+++ b/src/profile.h
@@ -65,6 +65,7 @@ typedef struct profile_context {
 
   FILE_TIMESTAMP elapsed;       /*!< Total time running remake */
   const struct goaldep *entry;  /*!< Pointer to chain of entries to remake */
+  const char *output_dir;       /*!< Directory for output of profiling information */
 } profile_context_t;
 
 /*! \brief Function for processing a profile entry for output */


### PR DESCRIPTION
A project I work on uses recursive make extensively and I was trying to profile our build.There wasn't an easy way to correlate the individual callgrind.out files so I extended the functionality to pass PID and target to the recursive calls to make. I needed to parse the output to stitch the different files together so I added functionality to output as json.

There is a significant difference in how I am capturing timestamps. The current implementation increments the time when a target is actively being evaluated. However, I think the relevant metric is how long the target takes from the moment it is first considered until it is marked as completed. I also capture a timestamp when the recipe begins running.

* Extract output formatting from profile.c into callgrind_format.c
* Capture timestamps based on target state with profile_add_timestamp
* Capture dependencies explicitly with profile_add_dependency
* Add MAKEPARENT_PID to pass PID to recursive make
* Add MAKEPARENT_TARGET to pass target name to recursive make
* Add --profile-callgrind to output just callgrind files
* Add --profile-json to output just json files
* Use file_timestamp_now to capture timestamp and resolution
* Add --with-profiler-resolution to specify minimum timestamp resolution
required