### PR TITLE
Add links to next/previous page

### DIFF
--- a/doc/readthedocs/conf.py
+++ b/doc/readthedocs/conf.py
@@ -93,7 +93,9 @@ html_theme = 'alabaster'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+	'show_relbar_bottom' : 'true'
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
- This adds 'next' / 'previous' links to the bottom of pages.
- For this to work alabaster 0.7.11+ has to be installed.
- Fixes bug/feature request [#120](https://github.com/rocky/remake/issues/120)

Below an example how it would look:
![Screenshot alabaster with next prev](https://user-images.githubusercontent.com/52218/135216599-3ea0fa9b-a24b-4fd7-8ad9-727a4e14ad45.jpg)
