### PR TITLE
Only print one right square bracket in entries

### DIFF
--- a/src/json_format.c
+++ b/src/json_format.c
@@ -183,8 +183,8 @@ dump_entry(FILE *fd, const struct goaldep *entry)
     } else {
       fprintf(fd, "\"\n");
     }
-    fprintf(fd, LVL1 "],\n");
   }
+  fprintf(fd, LVL1 "],\n");
 }
 
 static void


### PR DESCRIPTION
The right square bracket was inside the loop rather than outside.