### PR TITLE
Tweak MAKEFLAGS and -X interaction

### DIFF
--- a/libdebugger/command/continue.c
+++ b/libdebugger/command/continue.c
@@ -27,6 +27,7 @@ Boston, MA 02111-1307, USA.  */
 
 #include "../../src/trace.h"
 #include "../../src/expand.h"
+#include "../../src/globals.h"
 #include "../break.h"
 #include "../fns.h"
 #include "../stack.h"
@@ -75,8 +76,8 @@ dbg_cmd_continue (char *psz_args)
 
   i_debugger_stepping = 0;
   i_debugger_nexting  = 0;
-  define_variable_in_set("MAKEFLAGS", sizeof("MAKEFLAGS")-1,
-                         "", o_debugger, 0, NULL, NULL);
+  debugger_flag = 0;
+  define_makeflags (1, 0);
   return continue_execution;
 };
 

--- a/libdebugger/command/finish.c
+++ b/libdebugger/command/finish.c
@@ -29,6 +29,7 @@ Boston, MA 02111-1307, USA.  */
 
 #include "../../src/trace.h"
 #include "../../src/variable.h"
+#include "../../src/globals.h"
 #include "../stack.h"
 #include "../cmd.h"
 #include "../fns.h"
@@ -56,8 +57,8 @@ dbg_cmd_finish(char *psz_amount)
     i_debugger_nexting  = 0;
     i_debugger_stepping = 0;
     p->p_shared_target->tracing |= (BRK_AFTER_CMD);
-    define_variable_in_set("MAKEFLAGS", sizeof("MAKEFLAGS")-1,
-                         "", o_debugger, 0, NULL, NULL);
+    debugger_flag = 0;
+    define_makeflags (1, 0);
     return continue_execution;
   } else {
     if (i > i_amount)

--- a/libdebugger/command/next.c
+++ b/libdebugger/command/next.c
@@ -29,6 +29,7 @@ Boston, MA 02111-1307, USA.  */
 #include "../../src/trace.h"
 #include "../../src/debug.h"
 #include "../../src/variable.h"
+#include "../../src/globals.h"
 #include "../fns.h"
 
 extern debug_return_t
@@ -37,8 +38,8 @@ dbg_cmd_next(char *psz_arg)
   if (!psz_arg || !*psz_arg) {
     i_debugger_nexting  = 1;
     i_debugger_stepping = 0;
-    define_variable_in_set("MAKEFLAGS", sizeof("MAKEFLAGS")-1,
-                         "", o_debugger, 0, NULL, NULL);
+    debugger_flag = 0;
+    define_makeflags (1, 0);
     return continue_execution;
   }
   if (get_uint(psz_arg, &i_debugger_nexting, true))

--- a/libdebugger/command/step.c
+++ b/libdebugger/command/step.c
@@ -29,6 +29,7 @@ Boston, MA 02111-1307, USA.  */
 #include "../../src/trace.h"
 #include "../../src/debug.h"
 #include "../../src/variable.h"
+#include "../../src/globals.h"
 #include "../fns.h"
 
 extern debug_return_t
@@ -37,13 +38,13 @@ dbg_cmd_step (char *psz_arg)
   if (!psz_arg || !*psz_arg) {
     i_debugger_stepping = 1;
     i_debugger_nexting  = 0;
-    define_variable_in_set("MAKEFLAGS", sizeof("MAKEFLAGS")-1,
-                           "X", o_debugger, 0, NULL, NULL);
+    debugger_flag = 1;
+    define_makeflags (1, 0);
     return continue_execution;
   }
   if (get_uint(psz_arg, &i_debugger_stepping, true)) {
-    define_variable_in_set("MAKEFLAGS", sizeof("MAKEFLAGS")-1,
-                           "X", o_debugger, 0, NULL, NULL);
+    debugger_flag = 1;
+    define_makeflags (1, 0);
     i_debugger_nexting  = 0;
     return continue_execution;
   } else

--- a/src/main.c
+++ b/src/main.c
@@ -69,7 +69,6 @@ void print_rule_data_base (bool b_verbose);
 static void print_version (void);
 static void decode_switches (int argc, const char **argv, int env);
 static void decode_env_switches (const char *envar, size_t len);
-static struct variable *define_makeflags (int all, int makefile);
 static char *quote_for_env (char *out, const char *in);
 static void initialize_global_hash_tables (void);
 
@@ -2932,7 +2931,7 @@ quote_for_env (char *out, const char *in)
    command switches.  Include options with args if ALL is nonzero.
    Don't include options with the 'no_makefile' flag set if MAKEFILE.  */
 
-static struct variable *
+struct variable *
 define_makeflags (int all, int makefile)
 {
   const char ref[] = "MAKEOVERRIDES";
@@ -2990,7 +2989,7 @@ define_makeflags (int all, int makefile)
           if ((!*(int *) cs->value_ptr) == (cs->type == flag_off)
               && (cs->default_value == 0
                   || *(int *) cs->value_ptr != *(int *) cs->default_value))
-	    if (cs->c != 'X') ADD_FLAG (0, 0);
+	    ADD_FLAG (0, 0);
           break;
 
         case positive_int:
@@ -3077,10 +3076,8 @@ define_makeflags (int all, int makefile)
   /* Add simple options as a group.  */
   while (flags != 0 && !flags->arg && short_option (flags->cs->c))
     {
-      if (flags->cs->c != 'X') {
-        *p++ = (char) flags->cs->c;
-        flags = flags->next;
-      }
+      *p++ = (char) flags->cs->c;
+      flags = flags->next;
     }
 
   /* Now add more complex flags: ones with options and/or long names.  */

--- a/src/variable.h
+++ b/src/variable.h
@@ -290,6 +290,9 @@ struct pattern_var *create_pattern_var (const char *target,
 
 extern int export_all_variables;
 
+struct variable *
+define_makeflags (int all, int makefile);
+
 #define MAKELEVEL_NAME "MAKELEVEL"
 #define MAKELEVEL_LENGTH (CSTRLEN (MAKELEVEL_NAME))
 


### PR DESCRIPTION
Hi, this patch addresses an issue I had using remake with Linux's build system. The issue is described in the commit message.

The mechanism introduced is a little clunky and it uses global state, but I've been using remake with this patch applied for a while and it does not seem to break anything.