### PR TITLE
Fix remake info header

### DIFF
--- a/doc/remake.texi
+++ b/doc/remake.texi
@@ -69,7 +69,7 @@
 @c manuals to an info tree.
 @dircategory Programming & development tools.
 @direntry
-* remake: (@value{DBG}).                     The @MAKE extensions and debugger.
+* Remake: (remake).                       The @MAKE extensions and debugger.
 @end direntry
 
 @ifinfo


### PR DESCRIPTION
The item in parenthesis has to be the basename of the info file, otherwise `mRemake` from within `info` gets error
"Cannot find node ''".

While being about it, insert 2 spaces before description, to align with previous entry in dir.