### PR TITLE
Ensure autogen.sh exits nonzero if autoreconf fails

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,12 +6,7 @@
 MAKE=${MAKE:-make}
 
 echo "Rebuilding ./configure with autoreconf..."
-autoreconf -f -i
-
-if [ $? -ne 0 ]; then
-  echo "autoreconf failed"
-  exit $?
-fi
+autoreconf -f -i || { rc=$?; echo "autoreconf failed"; exit $rc; }
 
 # Add our target descriptions to po/Makefile.in.in
 patch -p0 < po/Makefile.in.in.patch


### PR DESCRIPTION
You need to capture the value of $? immediately: it doesn't survive "if ...;else" let alone "echo".

Sorry about this trivial change but I want to do something else with autogen.sh so get this out the way first.