### PR TITLE
Ensure consistent results if autogen.sh is run more than once

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -5,6 +5,9 @@
 # honor MAKE variable if set otherwise set it to `make'
 MAKE=${MAKE:-make}
 
+# Guard against being run more than once
+(cd build-aux && rm -f mdate-sh texinfo.tex)
+
 echo "Rebuilding ./configure with autoreconf..."
 autoreconf -f -i || { rc=$?; echo "autoreconf failed"; exit $rc; }
 


### PR DESCRIPTION
Without this patch, make dist after a second autogen.sh will generate a Makefile.in that differs from after the first autogen.sh:

diff t5/remake-4.3-1+dbg-1.6/Makefile.in t6/remake-4.3-1+dbg-1.6/Makefile.in 334c334,335
<       build-aux/install-sh build-aux/missing
---
>       build-aux/install-sh build-aux/mdate-sh build-aux/missing \
>       build-aux/texinfo.tex

But that is the only difference(!).
Make install results from either tarball are identical.

However the small change above does result in make dist-xz adding 440 bytes to the tarball.