### PR TITLE
Attempt to get --debugger-stop=goal to do something useful

### DIFF
--- a/libdebugger/fns.c
+++ b/libdebugger/fns.c
@@ -319,7 +319,10 @@ print_debugger_location(const file_t *p_target, debug_enter_reason_t reason,
 	   before the first command? Or should we list the line
 	   that the command starts on - so we know we've faked the location?
 	*/
-	floc.lineno--;
+	/* Not OK to subtract 1 if b_debugger_goal sent us here */
+	if (!b_debugger_goal) {
+	  floc.lineno--;
+	}
 	p_target_loc->filenm = floc.filenm;
 	p_target_loc->lineno = floc.lineno;
 	print_floc_prefix(&floc);

--- a/src/main.c
+++ b/src/main.c
@@ -1465,7 +1465,7 @@ main (int argc, const char **argv, char **envp)
             db_level           |= DB_UPDATE_GOAL;
           }
 
-          if ( 0 == strcmp(*p, "full") || b_debugger_preread
+          if ( 0 == strcmp(*p, "full") || b_debugger_preread || b_debugger_goal
                || 0 == strcmp(*p, "preaction") ) {
             job_slots            =  1;
             i_debugger_stepping  =  1;
@@ -1474,10 +1474,11 @@ main (int argc, const char **argv, char **envp)
             /* For now we'll do basic debugging. Later, "stepping'
                will stop here while next won't - either way no printing.
              */
-            db_level          |=  DB_BASIC | DB_CALL | DB_SHELL | DB_UPDATE_GOAL
+            db_level          |=  DB_BASIC | DB_CALL | DB_UPDATE_GOAL
+                              |   b_debugger_goal ? 0 : DB_SHELL
                               |   DB_MAKEFILES;
           }
-          if ( 0 == strcmp(*p, "full")
+          if ( 0 == strcmp(*p, "full") || b_debugger_goal
                || 0 == strcmp(*p, "error") ) {
             debugger_on_error  |=  (DEBUGGER_ON_ERROR|DEBUGGER_ON_FATAL);
           } else if ( 0 == strcmp(*p, "fatal") ) {

--- a/src/print.c
+++ b/src/print.c
@@ -309,7 +309,10 @@ print_target_stack_entry (const file_t *p_target, int i, int i_pos)
        before the first command? Or should we list the line
        that the command starts on - so we know we've faked the location?
     */
-    floc.lineno--;
+    /* Not OK to subtract 1 if b_debugger_goal sent us here */
+    if (!b_debugger_goal) {
+      floc.lineno--;
+    }
   } else {
     floc.filenm = NULL;
   }


### PR DESCRIPTION
From debugging, it became apparent that -X, --debugger is the same as --debugger-stop=full.
Also, -X causes --debugger-stop to be ignored.
All the --debugger-stop types seemed to work when -X was absent except --debugger-stop=goal.
With this patch, --debugger-stop=goal will stop on the first encountered goal.