### PR TITLE
Expand test to not use line number hack

### DIFF
--- a/libdebugger/fns.c
+++ b/libdebugger/fns.c
@@ -319,8 +319,8 @@ print_debugger_location(const file_t *p_target, debug_enter_reason_t reason,
 	   before the first command? Or should we list the line
 	   that the command starts on - so we know we've faked the location?
 	*/
-	/* Not OK to subtract 1 if b_debugger_goal sent us here */
-	if (!b_debugger_goal) {
+	/* Not OK to subtract 1 if already zero */
+	if (floc.lineno) {
 	  floc.lineno--;
 	}
 	p_target_loc->filenm = floc.filenm;

--- a/src/print.c
+++ b/src/print.c
@@ -309,8 +309,8 @@ print_target_stack_entry (const file_t *p_target, int i, int i_pos)
        before the first command? Or should we list the line
        that the command starts on - so we know we've faked the location?
     */
-    /* Not OK to subtract 1 if b_debugger_goal sent us here */
-    if (!b_debugger_goal) {
+    /* Not OK to subtract 1 if already zero */
+    if (floc.lineno) {
       floc.lineno--;
     }
   } else {


### PR DESCRIPTION
commit acfaa6f9 prevented subtracting 1 from unsigned zero floc.lineno after --debugger-stop=load had set b_debugger_goal. But --debugger-stop=full obeys that code as well, so simply test floc.lineno to be nonzero before subtracting. This doesn't affect autotools Makefiles but this generic Makefile displays it:
```
.PHONY: clean
SRCS = $(wildcard *.c)
PROG = $(shell basename $$PWD)
OBJ = $(SRCS:.c=.o)
CPPFLAGS = $(shell getconf LFS_CFLAGS 2>/dev/null)
CFLAGS := $(CFLAGS) -g3 -gdwarf-4 \
  -Wall -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wstrict-prototypes \
  -Wmissing-prototypes
$(PROG) : $(OBJ)
	$(CC) $^ -o $@ $(LIBS)
clean :
	rm -f *.o *.d $(PROG)

%.d: %.c
	$(CC) -MM -MT $(@:.d=.o) -MT $@ $(CPPFLAGS) $< -o $@
ifneq ($(MAKECMDGOALS),clean)
-include $(SRCS:.c=.d)
endif
```
Place this in a directory by itself with any random "hello world" program, remake --debugger-stop=full and step through.