### PR TITLE
Fix build without readline

### DIFF
--- a/libdebugger/cmd.c
+++ b/libdebugger/cmd.c
@@ -46,12 +46,12 @@ Boston, MA 02111-1307, USA.  */
 /* The following line makes Solaris' gcc/cpp not puke. */
 #undef HAVE_READLINE_READLINE_H
 #include <readline/readline.h>
+#endif /* HAVE_LIBREADLINE */
 
 /* From readline. ?? Should this be in configure?  */
 #ifndef whitespace
 #define whitespace(c) (((c) == ' ') || ((c) == '\t'))
 #endif
-#endif /* HAVE_LIBREADLINE */
 
 #include "cmd_initialize.h"
 
@@ -78,8 +78,6 @@ Boston, MA 02111-1307, USA.  */
 char *psz_debugger_args;
 
 debug_enter_reason_t last_stop_reason;
-
-#ifdef HAVE_LIBREADLINE
 
 short_cmd_t short_command[256] = { { NULL,
                                      (const char *) '\0',
@@ -225,8 +223,6 @@ extern debug_return_t dbg_cmd_set_var (char *psz_args, int expand)
   }
   return debug_readloop;
 }
-
-#endif /* HAVE_LIBREADLINE */
 
 #define PROMPT_LENGTH 300
 
@@ -381,10 +377,14 @@ debug_return_t enter_debugger (target_stack_node_t *p,
 
       if ( line ) {
         if ( *(s=stripwhite(line)) ) {
+#ifdef HAVE_LIBREADLINE
           add_history (s);
+#endif /* HAVE_LIBREADLINE */
           debug_return=execute_line(s);
         } else {
+#ifdef HAVE_LIBREADLINE
           add_history ("step");
+#endif /* HAVE_LIBREADLINE */
           debug_return=dbg_cmd_step((char *) "");
         }
         free (line);

--- a/libdebugger/command/set.c
+++ b/libdebugger/command/set.c
@@ -46,12 +46,12 @@ Boston, MA 02111-1307, USA.  */
 /* The following line makes Solaris' gcc/cpp not puke. */
 #undef HAVE_READLINE_READLINE_H
 #include <readline/readline.h>
+#endif /* HAVE_LIBREADLINE */
 
 /* From readline. ?? Should this be in configure?  */
 #ifndef whitespace
 #define whitespace(c) (((c) == ' ') || ((c) == '\t'))
 #endif
-#endif /* HAVE_LIBREADLINE */
 
 subcommand_var_info_t set_subcommands[] = {
   { "basename",


### PR DESCRIPTION
`readline` is an optional dependency, but building without it failed:

bits/stdio2.h:112: undefined reference to `short_command'
libdebugger/cmd.c:384: undefined reference to `add_history'
libdebugger/cmd.c:385: undefined reference to `execute_line'
libdebugger/cmd.c:387: undefined reference to `add_history'
libdebugger/cmd_initialize.h:117: undefined reference to `short_command'
libdebugger/cmd_initialize.h:118: undefined reference to `short_command'
libdebugger/cmd_initialize.h:124: undefined reference to `short_command'
libdebugger/cmd_initialize.h:349: undefined reference to `short_command'
libdebugger/command/help.c:120: undefined reference to `short_command'
libdebugger/command/help.c:126: undefined reference to `find_command'
libdebugger/command/set.c:124: undefined reference to `whitespace'
libdebugger/command/set.c:137: undefined reference to `dbg_cmd_set_var'
libdebugger/command/setq.c:32: undefined reference to `dbg_cmd_set_var'
libdebugger/command/setqx.c:32: undefined reference to `dbg_cmd_set_var'
libdebugger/command/show.c:115: undefined reference to `dbg_cmd_show_command'
libdebugger/command/source.c:74: undefined reference to `execute_line'

Closes: #157