### PR TITLE
GCC-15 tolerance

### DIFF
--- a/src/make.h
+++ b/src/make.h
@@ -415,11 +415,7 @@ long int lseek ();
 
 #endif  /* Not GNU C library or POSIX.  */
 
-#ifdef  HAVE_GETCWD
-# if !defined(VMS) && !defined(__DECC)
-char *getcwd ();
-# endif
-#else
+#ifndef HAVE_GETCWD
 char *getwd ();
 # define getcwd(buf, len)       getwd (buf)
 #endif

--- a/src/makeint.h
+++ b/src/makeint.h
@@ -611,11 +611,7 @@ long int lseek ();
 
 #endif  /* Not GNU C library or POSIX.  */
 
-#ifdef  HAVE_GETCWD
-# if !defined(VMS) && !defined(__DECC)
-char *getcwd ();
-# endif
-#else
+#ifndef HAVE_GETCWD
 char *getwd ();
 # define getcwd(buf, len)       getwd (buf)
 #endif


### PR DESCRIPTION
gcc-15 treats void f(); as void f(void); See #169.