### PR TITLE
Remake 4 4 ftbfs with gcc 15

### DIFF
--- a/src/make.h
+++ b/src/make.h
@@ -413,11 +413,7 @@ long int lseek ();
 
 #endif  /* Not GNU C library or POSIX.  */
 
-#ifdef  HAVE_GETCWD
-# if !defined(VMS) && !defined(__DECC)
-char *getcwd ();
-# endif
-#else
+#ifndef HAVE_GETCWD
 char *getwd ();
 # define getcwd(buf, len)       getwd (buf)
 #endif

--- a/src/makeint.h
+++ b/src/makeint.h
@@ -656,7 +656,7 @@ long int lseek ();
 
 #endif  /* Not GNU C library or POSIX.  */
 
-#ifdef  HAVE_GETCWD
+#ifdef HAVE_GETCWD
 # if !defined(VMS) && !defined(__DECC)
 char *getcwd ();
 # endif


### PR DESCRIPTION
gcc-15 treats void f(); as void f(void); See #169