### PR TITLE
Add --watch option for incremental rebuild on file-system changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,7 +39,9 @@ make_SRCS =	\
 		src/output.c src/print.c src/profile.c src/read.c src/remake.c \
 		src/rule.c src/rule.h src/signame.c src/strcache.c \
 		src/types.h  src/trace.c src/variable.c src/version.c src/vpath.c \
-		src/callgrind_format.c src/json_format.c src/watch.c
+		src/callgrind_format.c src/json_format.c \
+		src/watch.c src/watch_inotify.c src/watch_poll.c \
+		src/watchbackend.h
 
 glob_SRCS =	lib/fnmatch.c lib/fnmatch.h lib/glob.c lib/glob.h
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,7 +39,7 @@ make_SRCS =	\
 		src/output.c src/print.c src/profile.c src/read.c src/remake.c \
 		src/rule.c src/rule.h src/signame.c src/strcache.c \
 		src/types.h  src/trace.c src/variable.c src/version.c src/vpath.c \
-		src/callgrind_format.c src/json_format.c
+		src/callgrind_format.c src/json_format.c src/watch.c
 
 glob_SRCS =	lib/fnmatch.c lib/fnmatch.h lib/glob.c lib/glob.h
 

--- a/NEWS-remake.md
+++ b/NEWS-remake.md
@@ -10,6 +10,13 @@ Rebase code on GNU Make 4.4
 * Fix build without GNU readline or libreadline #157
 
 
+Unreleased
+==========
+
+* Add `--watch` option: stay running and rebuild on file-system changes
+  (Linux/inotify only).  Watches the transitive prerequisite set of the
+  named goals; re-execs on makefile changes for full re-parse.
+
 Version 4.3.1+dbg-1.6 (2022-01-22)
 ==================================
 

--- a/NEWS-remake.md
+++ b/NEWS-remake.md
@@ -13,9 +13,13 @@ Rebase code on GNU Make 4.4
 Unreleased
 ==========
 
-* Add `--watch` option: stay running and rebuild on file-system changes
-  (Linux/inotify only).  Watches the transitive prerequisite set of the
-  named goals; re-execs on makefile changes for full re-parse.
+* Add `--watch` option: stay running and rebuild on file-system changes.
+  Watches the transitive prerequisite set of the named goals; re-execs
+  on makefile changes for full re-parse.  Linux/Cygwin builds use
+  `inotify(7)` for instant wake-up; on every other platform (and with
+  `--without-inotify` on Linux for testing) a portable `stat()`-based
+  polling fallback is used (interval tunable via the
+  `MAKE_WATCH_POLL_INTERVAL` environment variable, default 1000 ms).
 
 Version 4.3.1+dbg-1.6 (2022-01-22)
 ==================================

--- a/configure.ac
+++ b/configure.ac
@@ -127,7 +127,19 @@ AC_HEADER_STAT
 
 AC_CHECK_HEADERS([stdlib.h string.h strings.h locale.h unistd.h limits.h \
                   memory.h sys/param.h sys/resource.h sys/time.h sys/select.h \
-                  sys/file.h fcntl.h spawn.h sys/inotify.h])
+                  sys/file.h fcntl.h spawn.h])
+
+# --watch backend selection: inotify when available, polling otherwise.
+# Pass --without-inotify to force the polling backend (useful for
+# testing the fallback on Linux).  No flag is needed on platforms
+# where <sys/inotify.h> is unavailable -- the probe just fails.
+AC_ARG_WITH([inotify],
+  [AS_HELP_STRING([--without-inotify],
+                  [do not use inotify(7) for --watch; use stat() polling instead])],
+  [],
+  [with_inotify=yes])
+AS_IF([test "x$with_inotify" != xno],
+  [AC_CHECK_HEADERS([sys/inotify.h])])
 
 AM_PROG_CC_C_O
 AC_C_CONST
@@ -157,14 +169,14 @@ AS_IF([test "$make_cv_file_timestamp_hi_res" = yes], [val=1], [val=0])
 AC_DEFINE_UNQUOTED([FILE_TIMESTAMP_HI_RES], [$val],
                    [Use high resolution file timestamps if nonzero.])
 
-AS_IF([test "$make_cv_file_timestamp_hi_res" = yes],
-[ # Solaris 2.5.1 needs -lposix4 to get the clock_gettime function.
-  # Solaris 7 prefers the library name -lrt to the obsolescent name -lposix4.
-  AC_SEARCH_LIBS([clock_gettime], [rt posix4])
-  AS_IF([test "$ac_cv_search_clock_gettime" != no],
-  [ AC_DEFINE([HAVE_CLOCK_GETTIME], [1],
-              [Define to 1 if you have the clock_gettime function.])
-  ])
+# Solaris 2.5.1 needs -lposix4 to get the clock_gettime function.
+# Solaris 7 prefers the library name -lrt to the obsolescent name -lposix4.
+# The probe is unconditional so the --watch self-trigger guard can use
+# CLOCK_MONOTONIC regardless of file-timestamp resolution.
+AC_SEARCH_LIBS([clock_gettime], [rt posix4])
+AS_IF([test "$ac_cv_search_clock_gettime" != no],
+[ AC_DEFINE([HAVE_CLOCK_GETTIME], [1],
+            [Define to 1 if you have the clock_gettime function.])
 ])
 
 # See if we have a standard version of gettimeofday().  Since actual
@@ -192,7 +204,7 @@ AC_CHECK_FUNCS([strtoll strdup strndup stpcpy memrchr mempcpy umask mkstemp \
                 getgroups seteuid setegid setlinebuf setreuid setregid \
                 mkfifo getrlimit setrlimit setvbuf pipe strerror strsignal \
                 lstat readlink atexit isatty ttyname pselect posix_spawn \
-                posix_spawnattr_setsigmask])
+                posix_spawnattr_setsigmask nanosleep])
 
 # We need to check declarations, not just existence, because on Tru64 this
 # function is not declared without special flags, which themselves cause

--- a/configure.ac
+++ b/configure.ac
@@ -127,7 +127,7 @@ AC_HEADER_STAT
 
 AC_CHECK_HEADERS([stdlib.h string.h strings.h locale.h unistd.h limits.h \
                   memory.h sys/param.h sys/resource.h sys/time.h sys/select.h \
-                  sys/file.h fcntl.h spawn.h])
+                  sys/file.h fcntl.h spawn.h sys/inotify.h])
 
 AM_PROG_CC_C_O
 AC_C_CONST

--- a/doc/remake.texi
+++ b/doc/remake.texi
@@ -1065,6 +1065,7 @@ are a number of handy extensions to @value{MAKE} that we list here.
 * Comments::     Listing and Documenting Makefile Targets
 * Searching::    Searching for a Makefile in Parent Directories
 * Improved-Tracing::      Improved Execution Tracing
+* Watching::     Rebuild on file-system changes
 @end menu
 
 @node Profiling and Visualization
@@ -1285,6 +1286,39 @@ If different granularity of tracing is desired the @code{--trace} option
 has other settings. See the relevant parts of this manual for more information.
 
 And, if you the most flexibility in tracing there is a built-in debugger.
+
+@node Watching
+@section Rebuild on file-system changes
+
+@cindex @code{--watch}
+@cindex incremental rebuild
+
+@smallexample
+  $ remake --watch # target...
+@end smallexample
+
+When the @code{--watch} flag is given, @value{REMAKE} performs the
+requested build once and then stays running, watching the file system
+for changes to any file that is a transitive prerequisite of the named
+goals (or the default goal, if none was named).  When such a file
+changes, @value{REMAKE} re-runs @code{update_goal_chain} in-process,
+which means only targets whose dependencies have actually changed are
+remade --- exactly as a normal @code{remake} invocation would decide.
+
+If a @emph{makefile} that was read changes, @value{REMAKE} re-executes
+itself with the original argument list, so the makefiles are re-parsed
+from scratch.  This is the only behavior consistent with normal make
+semantics.
+
+@code{--watch} is incompatible with @code{-t}/@code{--touch}, since
+touching watched targets would cause the watcher to fire on its own
+output.  Other options (@code{-n}, @code{-q}, @code{-W}, @code{-p},
+etc.) work as documented; in particular, @code{-n} is a useful way
+to see, on each change, what @emph{would} be rebuilt.
+
+This feature requires Linux @code{inotify} (build-time
+@code{<sys/inotify.h>}); on platforms without it, @code{--watch}
+fails with a clear error.  Press @kbd{Ctrl-C} to stop watching.
 
 @node Invocation
 @chapter Getting in and out and new @value{REMAKE} Command Options

--- a/doc/remake.texi
+++ b/doc/remake.texi
@@ -1316,9 +1316,13 @@ output.  Other options (@code{-n}, @code{-q}, @code{-W}, @code{-p},
 etc.) work as documented; in particular, @code{-n} is a useful way
 to see, on each change, what @emph{would} be rebuilt.
 
-This feature requires Linux @code{inotify} (build-time
-@code{<sys/inotify.h>}); on platforms without it, @code{--watch}
-fails with a clear error.  Press @kbd{Ctrl-C} to stop watching.
+On Linux and Cygwin (when @code{<sys/inotify.h>} is available)
+@code{--watch} uses @code{inotify(7)} for instant wake-up.  Pass
+@code{--without-inotify} to @code{configure} to force the portable
+fallback.  On every other platform a @code{stat(2)}-based polling
+backend is used; its tick interval can be tuned with the
+@code{MAKE_WATCH_POLL_INTERVAL} environment variable (milliseconds;
+default 1000).  Press @kbd{Ctrl-C} to stop watching.
 
 @node Invocation
 @chapter Getting in and out and new @value{REMAKE} Command Options

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -58,4 +58,6 @@ src/variable.c
 src/variable.h
 src/vpath.c
 src/watch.c
+src/watch_inotify.c
+src/watch_poll.c
 src/w32/w32os.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -57,4 +57,5 @@ src/strcache.c
 src/variable.c
 src/variable.h
 src/vpath.c
+src/watch.c
 src/w32/w32os.c

--- a/src/main.c
+++ b/src/main.c
@@ -130,6 +130,9 @@ bool b_show_version = false;
 Sets --debugger --debugger-stop=error. */
 int post_mortem_flag = 0;
 
+/*! Nonzero means watch the goal subgraph and rebuild on changes. */
+int watch_flag = 0;
+
 /*! Nonzero means use GNU readline in the debugger. */
 int use_readline_flag =
 #ifdef HAVE_LIBREADLINE
@@ -375,6 +378,9 @@ static const char *const usage[] =
   -W FILE, --what-if=FILE, --new-file=FILE, --assume-new=FILE\n\
                               Consider FILE to be infinitely new.\n"),
     N_("\
+  --watch                     Stay running and rebuild affected targets on\n\
+                              file-system changes (requires inotify).\n"),
+    N_("\
   --warn-undefined-variables  Warn when an undefined variable is referenced.\n"),
     N_("\
   -x, --trace[=TYPE]          Trace command execution TYPE may be\n\
@@ -470,6 +476,7 @@ static const struct command_switch switches[] =
       "debugger-stop" },
     { CHAR_MAX+15, filename, &profile_dir_opt, 1, 1, 0, 0, 0, "profile-directory" },
     { CHAR_MAX+16, string, &jobserver_style, 1, 0, 0, 0, 0, "jobserver-style" },
+    { CHAR_MAX+17, flag, &watch_flag, 1, 1, 0, 0, 0, "watch" },
     { 0, 0, 0, 0, 0, 0, 0, 0, 0 }
   };
 
@@ -2538,6 +2545,21 @@ main (int argc, const char **argv, char **envp)
   /* Update the goals.  */
 
   DB (DB_BASIC, (_("Updating goal targets...\n")));
+
+  if (watch_flag)
+    {
+      if (touch_flag)
+        O (fatal, NILF,
+           _("--watch is incompatible with -t/--touch"));
+#ifdef HAVE_SYS_INOTIFY_H
+      watch_loop (goals, argc, (char **)argv);
+      /* watch_loop only returns on fatal error or signal. */
+      die (MAKE_FAILURE);
+#else
+      O (fatal, NILF,
+         _("--watch was requested but inotify is not available on this build"));
+#endif
+    }
 
   {
     switch (update_goal_chain (goals))

--- a/src/main.c
+++ b/src/main.c
@@ -379,7 +379,7 @@ static const char *const usage[] =
                               Consider FILE to be infinitely new.\n"),
     N_("\
   --watch                     Stay running and rebuild affected targets on\n\
-                              file-system changes (requires inotify).\n"),
+                              file-system changes.\n"),
     N_("\
   --warn-undefined-variables  Warn when an undefined variable is referenced.\n"),
     N_("\
@@ -2551,14 +2551,9 @@ main (int argc, const char **argv, char **envp)
       if (touch_flag)
         O (fatal, NILF,
            _("--watch is incompatible with -t/--touch"));
-#ifdef HAVE_SYS_INOTIFY_H
-      watch_loop (goals, argc, (char **)argv);
+      watch_loop (goals, read_makefiles, argc, (char **)argv);
       /* watch_loop only returns on fatal error or signal. */
       die (MAKE_FAILURE);
-#else
-      O (fatal, NILF,
-         _("--watch was requested but inotify is not available on this build"));
-#endif
     }
 
   {

--- a/src/makeint.h
+++ b/src/makeint.h
@@ -703,7 +703,8 @@ extern int not_parallel, second_expansion, clock_skew_detected;
 extern int rebuilding_makefiles, one_shell, output_sync, verify_flag;
 extern int watch_flag;
 struct goaldep;
-void watch_loop (struct goaldep *goals, int argc, char **argv);
+void watch_loop (struct goaldep *goals, struct goaldep *read_files,
+                 int argc, char **argv);
 
 /* can we run commands via 'sh -c xxx' or must we use batch files? */
 extern int batch_mode_shell;

--- a/src/makeint.h
+++ b/src/makeint.h
@@ -701,6 +701,9 @@ extern int print_version_flag, print_directory, check_symlink_flag;
 extern int warn_undefined_variables_flag, trace_flag, posix_pedantic;
 extern int not_parallel, second_expansion, clock_skew_detected;
 extern int rebuilding_makefiles, one_shell, output_sync, verify_flag;
+extern int watch_flag;
+struct goaldep;
+void watch_loop (struct goaldep *goals, int argc, char **argv);
 
 /* can we run commands via 'sh -c xxx' or must we use batch files? */
 extern int batch_mode_shell;

--- a/src/watch.c
+++ b/src/watch.c
@@ -1,0 +1,495 @@
+/* --watch loop for remake: rebuild on file-system changes.
+
+   Co-inductive by design: the outer event loop only progresses when the
+   user (or a build tool) modifies a watched file.  The only inductive
+   risk -- a rebuild that triggers itself -- is bounded by a counter
+   below (SELF_TRIGGER_HALT) which warns then aborts.
+
+   For non-makefile sources we do an in-process rebuild
+   (update_goal_chain) for speed.  When a *makefile* changes we
+   re-exec ourselves with the original argv, which is the only
+   behavior consistent with normal make semantics (re-parse from
+   scratch).  This mirrors what main.c does at the bootstrap re_exec:
+   label; we deliberately use a simpler execvp here to keep the patch
+   minimal -- see main.c around the re_exec label for the fuller
+   ceremony (MAKE_RESTARTS bookkeeping, stdin temp file fixup) which
+   we do not need in the watch case.  */
+
+#include "makeint.h"
+
+#ifdef HAVE_SYS_INOTIFY_H
+
+#include "filedef.h"
+#include "dep.h"
+#include "debug.h"
+#include "os.h"
+
+#include <sys/inotify.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <poll.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <libgen.h>
+#include <time.h>
+
+/* Tunables.  Kept conservative; expose later as env vars if needed.  */
+#define DEBOUNCE_MS            50
+#define DEBOUNCE_MAX_EVENTS    10000
+#define EVENT_BUF_BYTES        (64 * 1024)
+#define SELF_TRIGGER_WARN      3
+#define SELF_TRIGGER_HALT      10
+#define SELF_TRIGGER_WINDOW_NS 200000000L  /* 200ms */
+
+/* A directory we watch.  We watch the *directory* (not the file) so
+   atomic-replace saves (vim, most editors) don't detach the watch.
+   Each entry tracks the basenames in that directory we care about,
+   so changes to unrelated siblings can be filtered out.  */
+struct watched_dir
+{
+  int wd;                       /* inotify watch descriptor */
+  char *path;                   /* directory path (owned) */
+  char **basenames;             /* names of files we care about */
+  int n_basenames;
+  int cap_basenames;
+  unsigned int is_makefile_dir : 1;
+};
+
+static int notify_fd = -1;
+static struct watched_dir *src_dirs = NULL;
+static int n_src_dirs = 0, cap_src_dirs = 0;
+static struct watched_dir *mk_dirs = NULL;
+static int n_mk_dirs = 0, cap_mk_dirs = 0;
+
+/* For self-trigger detection.  */
+static int self_trigger_count = 0;
+static struct timespec last_build_finished;
+
+/* DFS visited set: pointer-identity, linear-probed open addressing.
+   Tiny hash table, sized to power of two >= 2 * |goal subgraph|.  */
+struct visited_set
+{
+  struct file **slots;
+  size_t cap;
+  size_t n;
+};
+
+static void
+visited_init (struct visited_set *v, size_t hint)
+{
+  size_t cap = 16;
+  while (cap < hint * 2) cap <<= 1;
+  v->slots = xcalloc (cap * sizeof (struct file *));
+  v->cap = cap;
+  v->n = 0;
+}
+
+static void
+visited_free (struct visited_set *v)
+{
+  free (v->slots);
+  v->slots = NULL;
+  v->cap = v->n = 0;
+}
+
+static int
+visited_add (struct visited_set *v, struct file *f)
+{
+  size_t mask = v->cap - 1;
+  size_t i = ((uintptr_t) f >> 4) & mask;
+  while (v->slots[i])
+    {
+      if (v->slots[i] == f) return 0;       /* already present */
+      i = (i + 1) & mask;
+    }
+  v->slots[i] = f;
+  v->n++;
+  /* Grow if load factor > 0.5.  */
+  if (v->n * 2 > v->cap)
+    {
+      struct file **old = v->slots;
+      size_t old_cap = v->cap;
+      v->cap *= 2;
+      v->slots = xcalloc (v->cap * sizeof (struct file *));
+      v->n = 0;
+      for (size_t k = 0; k < old_cap; k++)
+        if (old[k]) visited_add (v, old[k]);
+      free (old);
+    }
+  return 1;
+}
+
+/* Add basename to dir entry if not present.  */
+static void
+dir_add_basename (struct watched_dir *d, const char *base)
+{
+  for (int i = 0; i < d->n_basenames; i++)
+    if (strcmp (d->basenames[i], base) == 0) return;
+  if (d->n_basenames == d->cap_basenames)
+    {
+      d->cap_basenames = d->cap_basenames ? d->cap_basenames * 2 : 4;
+      d->basenames = xrealloc (d->basenames,
+                               d->cap_basenames * sizeof (char *));
+    }
+  d->basenames[d->n_basenames++] = xstrdup (base);
+}
+
+static struct watched_dir *
+find_or_add_dir (struct watched_dir **arr, int *n, int *cap,
+                 const char *path, int is_makefile_dir)
+{
+  /* CLOSE_WRITE coalesces in-progress writes; MOVED_TO catches editor
+     atomic-replace; CREATE/DELETE catch newly-added/removed prereqs.
+     IN_MODIFY and IN_ATTRIB are intentionally omitted -- they fire
+     mid-write and on metadata-only changes, producing spurious
+     wakeups.  */
+  const uint32_t mask = IN_CLOSE_WRITE | IN_MOVED_TO | IN_CREATE | IN_DELETE;
+  struct watched_dir *d;
+  int i;
+
+  for (i = 0; i < *n; i++)
+    if (strcmp ((*arr)[i].path, path) == 0)
+      return &(*arr)[i];
+
+  if (*n == *cap)
+    {
+      *cap = *cap ? *cap * 2 : 8;
+      *arr = xrealloc (*arr, *cap * sizeof (struct watched_dir));
+    }
+  d = &(*arr)[*n];
+  memset (d, 0, sizeof *d);
+  d->path = xstrdup (path);
+  d->is_makefile_dir = is_makefile_dir ? 1 : 0;
+
+  d->wd = inotify_add_watch (notify_fd, path, mask);
+  if (d->wd < 0)
+    {
+      OSS (error, NILF, _("--watch: cannot watch directory '%s': %s"),
+           path, strerror (errno));
+      free (d->path);
+      d->path = NULL;
+      return NULL;
+    }
+  (*n)++;
+  return d;
+}
+
+/* Split f->name into (dirpath, basename) using a writable copy.
+   Returns 0 on success.  Caller frees *dir_out.  */
+static int
+split_path (const char *name, char **dir_out, char **base_out,
+            char **scratch_out)
+{
+  char *scratch_dir = xstrdup (name);
+  char *scratch_base = xstrdup (name);
+  *dir_out = xstrdup (dirname (scratch_dir));
+  *base_out = xstrdup (basename (scratch_base));
+  free (scratch_dir);
+  free (scratch_base);
+  *scratch_out = NULL;
+  return 0;
+}
+
+/* Add the file f to the source watch set if it is a leaf source --
+   not phony, has a real name on disk, and is not itself a build
+   product (no recipe attached).  Watching build outputs would make
+   each successful build trigger the next one.  */
+static void
+watch_one_source (struct file *f)
+{
+  char *dir, *base, *scratch;
+  struct watched_dir *d;
+
+  if (!f || !f->name) return;
+  if (f->phony) return;
+  if (f->cmds) return;
+  if (f->name[0] == '\0') return;
+
+  if (split_path (f->name, &dir, &base, &scratch) != 0) return;
+
+  d = find_or_add_dir (&src_dirs, &n_src_dirs, &cap_src_dirs, dir, 0);
+  if (d) dir_add_basename (d, base);
+
+  free (dir);
+  free (base);
+}
+
+/* DFS the goal subgraph collecting watch entries.  */
+static void
+collect_watched (struct file *f, struct visited_set *seen)
+{
+  if (!f) return;
+  while (f->renamed) f = f->renamed;
+  if (!visited_add (seen, f)) return;
+
+  watch_one_source (f);
+
+  for (struct dep *d = f->deps; d; d = d->next)
+    if (d->file) collect_watched (d->file, seen);
+  for (struct dep *d = f->also_make; d; d = d->next)
+    if (d->file) collect_watched (d->file, seen);
+}
+
+static void
+build_source_watch_set (struct goaldep *goals)
+{
+  struct visited_set seen;
+  visited_init (&seen, 64);
+  for (struct goaldep *g = goals; g; g = g->next)
+    if (g->file) collect_watched (g->file, &seen);
+  visited_free (&seen);
+}
+
+/* read_makefiles is the chain remake parsed; watch each entry's
+   directory.  This set is computed once per process: any change here
+   triggers re-exec, and the new process recomputes from scratch.  */
+static void
+build_makefile_watch_set (void)
+{
+  struct goaldep *g;
+  char *dir, *base, *scratch;
+  struct watched_dir *d;
+
+  for (g = read_makefiles; g; g = g->next)
+    {
+      if (!g->file || !g->file->name) continue;
+      if (split_path (g->file->name, &dir, &base, &scratch) != 0) continue;
+      d = find_or_add_dir (&mk_dirs, &n_mk_dirs, &cap_mk_dirs, dir, 1);
+      if (d) dir_add_basename (d, base);
+      free (dir); free (base);
+    }
+}
+
+/* Reset per-build state on the goal subgraph so update_goal_chain
+   re-evaluates everything.  Walking via DFS keeps us scoped: we never
+   reset files outside the goals' transitive prereqs.  */
+static void
+reset_one (struct file *f, struct visited_set *seen)
+{
+  if (!f) return;
+  while (f->renamed) f = f->renamed;
+  if (!visited_add (seen, f)) return;
+
+  f->last_mtime = UNKNOWN_MTIME;
+  f->mtime_before_update = UNKNOWN_MTIME;
+  f->updated = 0;
+  f->considered = 0;
+  f->command_state = cs_not_started;
+  f->update_status = us_none;
+
+  for (struct dep *d = f->deps; d; d = d->next)
+    {
+      d->changed = 0;
+      if (d->file) reset_one (d->file, seen);
+    }
+  for (struct dep *d = f->also_make; d; d = d->next)
+    if (d->file) reset_one (d->file, seen);
+}
+
+static void
+reset_goal_subgraph (struct goaldep *goals)
+{
+  struct visited_set seen;
+  visited_init (&seen, 64);
+  for (struct goaldep *g = goals; g; g = g->next)
+    if (g->file) reset_one (g->file, &seen);
+  visited_free (&seen);
+}
+
+/* Returns 1 if (wd, basename) hits the source set, 2 if makefile set,
+   0 if neither.  Makefile takes precedence on a tie -- a re-exec is a
+   superset of a rebuild.  */
+static int
+classify (int wd, const char *base)
+{
+  for (int i = 0; i < n_mk_dirs; i++)
+    if (mk_dirs[i].wd == wd)
+      for (int j = 0; j < mk_dirs[i].n_basenames; j++)
+        if (strcmp (mk_dirs[i].basenames[j], base) == 0)
+          return 2;
+  for (int i = 0; i < n_src_dirs; i++)
+    if (src_dirs[i].wd == wd)
+      for (int j = 0; j < src_dirs[i].n_basenames; j++)
+        if (strcmp (src_dirs[i].basenames[j], base) == 0)
+          return 1;
+  return 0;
+}
+
+/* Drain inotify events with a debounce.  Returns 1 if a source change
+   (or queue overflow) was seen, 2 if a makefile change was seen
+   (highest wins), 0 if no watched basenames matched (caller should
+   keep waiting), -1 on fatal read error.  Bounded by both DEBOUNCE_MS
+   and DEBOUNCE_MAX_EVENTS.  */
+static int
+wait_and_drain (void)
+{
+  char buf[EVENT_BUF_BYTES] __attribute__((aligned(8)));
+  struct pollfd pfd;
+  int kind = 0;
+  int events_seen = 0;
+  int r;
+
+  pfd.fd = notify_fd;
+  pfd.events = POLLIN;
+  pfd.revents = 0;
+
+  /* Block until first event arrives.  */
+  for (;;)
+    {
+      r = poll (&pfd, 1, -1);
+      if (r < 0)
+        {
+          if (errno == EINTR) return -1;     /* signal: caller decides */
+          OS (error, NILF, _("--watch: poll: %s"), strerror (errno));
+          return -1;
+        }
+      if (pfd.revents & POLLIN) break;
+    }
+
+  /* Then drain with short timeout to coalesce bursts.  */
+  for (;;)
+    {
+      ssize_t len = read (notify_fd, buf, sizeof buf);
+      char *p;
+      if (len < 0)
+        {
+          if (errno == EAGAIN
+#if EAGAIN != EWOULDBLOCK
+              || errno == EWOULDBLOCK
+#endif
+              ) break;
+          if (errno == EINTR) continue;
+          OS (error, NILF, _("--watch: read: %s"), strerror (errno));
+          return -1;
+        }
+      for (p = buf; p < buf + len; )
+        {
+          struct inotify_event *e = (struct inotify_event *) p;
+          if (e->mask & IN_Q_OVERFLOW)
+            return 1;                        /* lost events: force source rebuild */
+          if (e->len > 0)
+            {
+              int k = classify (e->wd, e->name);
+              if (k > kind) kind = k;
+            }
+          p += sizeof (struct inotify_event) + e->len;
+          if (++events_seen >= DEBOUNCE_MAX_EVENTS)
+            return kind;                     /* hard cap */
+        }
+      if (kind == 2) return 2;               /* makefile wins, no need to drain more */
+
+      pfd.revents = 0;
+      r = poll (&pfd, 1, DEBOUNCE_MS);
+      if (r <= 0) break;
+    }
+
+  /* If we got events but none matched watched basenames (e.g. build
+     outputs in the same directory), report kind=0.  The caller's outer
+     loop will go back to poll() and block until the next event, so
+     this does not spin.  */
+  return kind;
+}
+
+static long
+ts_diff_ns (const struct timespec *a, const struct timespec *b)
+{
+  return (a->tv_sec - b->tv_sec) * 1000000000L + (a->tv_nsec - b->tv_nsec);
+}
+
+void
+watch_loop (struct goaldep *goals, int argc, char **argv)
+{
+  /* Save argv for re-exec.  argv may live on the stack of main(); we
+     copy pointers, but the strings themselves are stable.  */
+  char **saved_argv = xmalloc ((argc + 1) * sizeof (char *));
+  enum update_status st;
+  int i;
+
+  for (i = 0; i < argc; i++) saved_argv[i] = argv[i];
+  saved_argv[argc] = NULL;
+
+  notify_fd = inotify_init1 (IN_CLOEXEC | IN_NONBLOCK);
+  if (notify_fd < 0)
+    {
+      OS (fatal, NILF, _("--watch: inotify_init: %s"), strerror (errno));
+      return;
+    }
+
+  /* Initial build, in-process, exactly as the non-watch path would.  */
+  st = update_goal_chain (goals);
+  if (st == us_failed)
+    O (error, NILF,
+       _("--watch: initial build failed; will retry on next change."));
+
+  build_source_watch_set (goals);
+  build_makefile_watch_set ();
+  clock_gettime (CLOCK_MONOTONIC, &last_build_finished);
+
+  /* Note: -p (print_data_base_flag) is honored on exit via die(),
+     same as the non-watch path.  */
+
+  O (message, 0, _("--watch: waiting for changes (Ctrl-C to stop)..."));
+
+  for (;;)
+    {
+      int kind;
+      struct timespec now;
+
+      kind = wait_and_drain ();
+      if (kind < 0)
+        {
+          /* Signal: let normal signal handling shut us down cleanly.  */
+          die (MAKE_FAILURE);
+        }
+      if (kind == 0)
+        continue;                            /* events were not for us */
+
+      clock_gettime (CLOCK_MONOTONIC, &now);
+
+      if (kind == 2)
+        {
+          /* Makefile change: re-exec for full re-parse.  Simpler than
+             the bootstrap re_exec path in main.c -- we have no stdin
+             temp file to preserve and no in-flight makefile rebuild.  */
+          O (message, 0,
+             _("--watch: makefile changed, re-executing remake."));
+          fflush (stdout);
+          fflush (stderr);
+          close (notify_fd);
+          execvp (saved_argv[0], saved_argv);
+          OS (fatal, NILF, _("--watch: execvp failed: %s"), strerror (errno));
+        }
+
+      /* Inductive-unboundedness guard: if the rebuild that just
+         finished is what triggered this wake (event came within
+         SELF_TRIGGER_WINDOW_NS of the build completing), assume the
+         rebuild touched its own watched outputs.  */
+      if (ts_diff_ns (&now, &last_build_finished) < SELF_TRIGGER_WINDOW_NS)
+        {
+          self_trigger_count++;
+          if (self_trigger_count == SELF_TRIGGER_WARN)
+            O (error, NILF,
+               _("--watch: warning: rebuild appears to trigger itself; "
+                 "check for recipes that touch their own watched outputs."));
+          if (self_trigger_count >= SELF_TRIGGER_HALT)
+            {
+              O (error, NILF,
+                 _("--watch: rebuild self-trigger limit reached, exiting."));
+              die (MAKE_FAILURE);
+            }
+        }
+      else
+        self_trigger_count = 0;
+
+      O (message, 0, _("--watch: change detected, rebuilding."));
+      reset_goal_subgraph (goals);
+      st = update_goal_chain (goals);
+      if (st == us_failed)
+        O (error, NILF, _("--watch: build failed; will retry on next change."));
+      build_source_watch_set (goals);  /* pick up new generated prereqs */
+      clock_gettime (CLOCK_MONOTONIC, &last_build_finished);
+    }
+}
+
+#endif /* HAVE_SYS_INOTIFY_H */

--- a/src/watch.c
+++ b/src/watch.c
@@ -1,70 +1,93 @@
-/* --watch loop for remake: rebuild on file-system changes.
+/* --watch event loop for remake: rebuild on file-system changes.
+Copyright (C) 2026 Free Software Foundation, Inc.
+This file is part of GNU Make / remake.
 
-   Co-inductive by design: the outer event loop only progresses when the
-   user (or a build tool) modifies a watched file.  The only inductive
-   risk -- a rebuild that triggers itself -- is bounded by a counter
-   below (SELF_TRIGGER_HALT) which warns then aborts.
+GNU Make is free software; you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation; either version 3 of the License, or (at your option) any later
+version.
+
+GNU Make is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+/* The outer event loop only progresses when the user (or a build tool)
+   modifies a watched file.  The one inductive risk -- a rebuild that
+   triggers itself -- is bounded by SELF_TRIGGER_HALT below, which warns
+   then aborts.
 
    For non-makefile sources we do an in-process rebuild
-   (update_goal_chain) for speed.  When a *makefile* changes we
-   re-exec ourselves with the original argv, which is the only
-   behavior consistent with normal make semantics (re-parse from
-   scratch).  This mirrors what main.c does at the bootstrap re_exec:
-   label; we deliberately use a simpler execvp here to keep the patch
-   minimal -- see main.c around the re_exec label for the fuller
-   ceremony (MAKE_RESTARTS bookkeeping, stdin temp file fixup) which
-   we do not need in the watch case.  */
+   (update_goal_chain) for speed.  When a makefile changes we re-exec
+   ourselves with the original argv, which is the only behavior
+   consistent with normal make semantics (re-parse from scratch).  This
+   is a simpler execvp than main.c's re_exec path -- we have no stdin
+   temp file to preserve and no in-flight makefile rebuild.
+
+   File-system-event detection is done by a backend selected at compile
+   time -- watch_inotify.c on Linux/Cygwin, watch_poll.c elsewhere --
+   behind the small interface in watchbackend.h.  */
 
 #include "makeint.h"
-
-#ifdef HAVE_SYS_INOTIFY_H
 
 #include "filedef.h"
 #include "dep.h"
 #include "debug.h"
 #include "os.h"
+#include "watchbackend.h"
 
-#include <sys/inotify.h>
 #include <sys/stat.h>
+#include <sys/time.h>
 #include <unistd.h>
-#include <poll.h>
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <libgen.h>
 #include <time.h>
 
-/* Tunables.  Kept conservative; expose later as env vars if needed.  */
-#define DEBOUNCE_MS            50
-#define DEBOUNCE_MAX_EVENTS    10000
-#define EVENT_BUF_BYTES        (64 * 1024)
-#define SELF_TRIGGER_WARN      3
-#define SELF_TRIGGER_HALT      10
-#define SELF_TRIGGER_WINDOW_NS 200000000L  /* 200ms */
+#define SELF_TRIGGER_WARN          3
+#define SELF_TRIGGER_HALT          10
+/* Floor for the self-trigger window.  The actual window used is
+   max(SELF_TRIGGER_WINDOW_MS_FLOOR, 2 * backend->min_latency_ms) so
+   the polling backend's tick (typically 1 s) does not silently
+   bypass the guard.  */
+#define SELF_TRIGGER_WINDOW_MS_FLOOR 200
 
-/* A directory we watch.  We watch the *directory* (not the file) so
-   atomic-replace saves (vim, most editors) don't detach the watch.
-   Each entry tracks the basenames in that directory we care about,
-   so changes to unrelated siblings can be filtered out.  */
-struct watched_dir
+/* mainline globals we need: directory the user was in before -C, so
+   we can restore it across the makefile-edit re-exec.  */
+extern char *directory_before_chdir;
+
+/* Monotonic time in milliseconds since some unspecified epoch, used
+   only for differences.  Falls back to gettimeofday() (POSIX.1-2001)
+   when clock_gettime() is unavailable; that fallback is wall-clock
+   and so a step backwards (NTP, manual date change) will produce a
+   negative diff -- callers must treat negative diffs as "long ago".  */
+static intmax_t
+monotonic_ms (void)
 {
-  int wd;                       /* inotify watch descriptor */
-  char *path;                   /* directory path (owned) */
-  char **basenames;             /* names of files we care about */
-  int n_basenames;
-  int cap_basenames;
-  unsigned int is_makefile_dir : 1;
-};
-
-static int notify_fd = -1;
-static struct watched_dir *src_dirs = NULL;
-static int n_src_dirs = 0, cap_src_dirs = 0;
-static struct watched_dir *mk_dirs = NULL;
-static int n_mk_dirs = 0, cap_mk_dirs = 0;
+#if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
+  struct timespec ts;
+  if (clock_gettime (CLOCK_MONOTONIC, &ts) == 0)
+    return (intmax_t) ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+#endif
+#ifdef HAVE_GETTIMEOFDAY
+  {
+    struct timeval tv;
+    if (gettimeofday (&tv, NULL) == 0)
+      return (intmax_t) tv.tv_sec * 1000 + tv.tv_usec / 1000;
+  }
+#endif
+  /* Last resort: 1-second resolution from time().  Self-trigger
+     guard becomes coarse but the loop still works.  */
+  return (intmax_t) time (NULL) * 1000;
+}
 
 /* For self-trigger detection.  */
 static int self_trigger_count = 0;
-static struct timespec last_build_finished;
+static intmax_t last_build_finished_ms = 0;
 
 /* DFS visited set: pointer-identity, linear-probed open addressing.
    Tiny hash table, sized to power of two >= 2 * |goal subgraph|.  */
@@ -98,6 +121,7 @@ visited_add (struct visited_set *v, struct file *f)
 {
   size_t mask = v->cap - 1;
   size_t i = ((uintptr_t) f >> 4) & mask;
+  size_t k;
   while (v->slots[i])
     {
       if (v->slots[i] == f) return 0;       /* already present */
@@ -113,73 +137,18 @@ visited_add (struct visited_set *v, struct file *f)
       v->cap *= 2;
       v->slots = xcalloc (v->cap * sizeof (struct file *));
       v->n = 0;
-      for (size_t k = 0; k < old_cap; k++)
+      for (k = 0; k < old_cap; k++)
         if (old[k]) visited_add (v, old[k]);
       free (old);
     }
   return 1;
 }
 
-/* Add basename to dir entry if not present.  */
+/* Split NAME into (dirpath, basename), writing freshly-allocated copies
+   to *DIR_OUT and *BASE_OUT.  Caller frees both.  POSIX dirname()/
+   basename() may modify their input, so we use scratch copies.  */
 static void
-dir_add_basename (struct watched_dir *d, const char *base)
-{
-  for (int i = 0; i < d->n_basenames; i++)
-    if (strcmp (d->basenames[i], base) == 0) return;
-  if (d->n_basenames == d->cap_basenames)
-    {
-      d->cap_basenames = d->cap_basenames ? d->cap_basenames * 2 : 4;
-      d->basenames = xrealloc (d->basenames,
-                               d->cap_basenames * sizeof (char *));
-    }
-  d->basenames[d->n_basenames++] = xstrdup (base);
-}
-
-static struct watched_dir *
-find_or_add_dir (struct watched_dir **arr, int *n, int *cap,
-                 const char *path, int is_makefile_dir)
-{
-  /* CLOSE_WRITE coalesces in-progress writes; MOVED_TO catches editor
-     atomic-replace; CREATE/DELETE catch newly-added/removed prereqs.
-     IN_MODIFY and IN_ATTRIB are intentionally omitted -- they fire
-     mid-write and on metadata-only changes, producing spurious
-     wakeups.  */
-  const uint32_t mask = IN_CLOSE_WRITE | IN_MOVED_TO | IN_CREATE | IN_DELETE;
-  struct watched_dir *d;
-  int i;
-
-  for (i = 0; i < *n; i++)
-    if (strcmp ((*arr)[i].path, path) == 0)
-      return &(*arr)[i];
-
-  if (*n == *cap)
-    {
-      *cap = *cap ? *cap * 2 : 8;
-      *arr = xrealloc (*arr, *cap * sizeof (struct watched_dir));
-    }
-  d = &(*arr)[*n];
-  memset (d, 0, sizeof *d);
-  d->path = xstrdup (path);
-  d->is_makefile_dir = is_makefile_dir ? 1 : 0;
-
-  d->wd = inotify_add_watch (notify_fd, path, mask);
-  if (d->wd < 0)
-    {
-      OSS (error, NILF, _("--watch: cannot watch directory '%s': %s"),
-           path, strerror (errno));
-      free (d->path);
-      d->path = NULL;
-      return NULL;
-    }
-  (*n)++;
-  return d;
-}
-
-/* Split f->name into (dirpath, basename) using a writable copy.
-   Returns 0 on success.  Caller frees *dir_out.  */
-static int
-split_path (const char *name, char **dir_out, char **base_out,
-            char **scratch_out)
+split_path (const char *name, char **dir_out, char **base_out)
 {
   char *scratch_dir = xstrdup (name);
   char *scratch_base = xstrdup (name);
@@ -187,8 +156,6 @@ split_path (const char *name, char **dir_out, char **base_out,
   *base_out = xstrdup (basename (scratch_base));
   free (scratch_dir);
   free (scratch_base);
-  *scratch_out = NULL;
-  return 0;
 }
 
 /* Add the file f to the source watch set if it is a leaf source --
@@ -196,68 +163,65 @@ split_path (const char *name, char **dir_out, char **base_out,
    product (no recipe attached).  Watching build outputs would make
    each successful build trigger the next one.  */
 static void
-watch_one_source (struct file *f)
+watch_one_source (struct watch_backend *wb, struct file *f)
 {
-  char *dir, *base, *scratch;
-  struct watched_dir *d;
-
+  char *dir, *base;
   if (!f || !f->name) return;
   if (f->phony) return;
   if (f->cmds) return;
   if (f->name[0] == '\0') return;
 
-  if (split_path (f->name, &dir, &base, &scratch) != 0) return;
-
-  d = find_or_add_dir (&src_dirs, &n_src_dirs, &cap_src_dirs, dir, 0);
-  if (d) dir_add_basename (d, base);
-
+  split_path (f->name, &dir, &base);
+  wb_add (wb, dir, base, 0 /* source */);
   free (dir);
   free (base);
 }
 
 /* DFS the goal subgraph collecting watch entries.  */
 static void
-collect_watched (struct file *f, struct visited_set *seen)
+collect_watched (struct watch_backend *wb, struct file *f,
+                 struct visited_set *seen)
 {
+  struct dep *d;
   if (!f) return;
   while (f->renamed) f = f->renamed;
   if (!visited_add (seen, f)) return;
 
-  watch_one_source (f);
+  watch_one_source (wb, f);
 
-  for (struct dep *d = f->deps; d; d = d->next)
-    if (d->file) collect_watched (d->file, seen);
-  for (struct dep *d = f->also_make; d; d = d->next)
-    if (d->file) collect_watched (d->file, seen);
+  for (d = f->deps; d; d = d->next)
+    if (d->file) collect_watched (wb, d->file, seen);
+  for (d = f->also_make; d; d = d->next)
+    if (d->file) collect_watched (wb, d->file, seen);
 }
 
 static void
-build_source_watch_set (struct goaldep *goals)
+build_source_watch_set (struct watch_backend *wb, struct goaldep *goals)
 {
   struct visited_set seen;
+  struct goaldep *g;
   visited_init (&seen, 64);
-  for (struct goaldep *g = goals; g; g = g->next)
-    if (g->file) collect_watched (g->file, &seen);
+  for (g = goals; g; g = g->next)
+    if (g->file) collect_watched (wb, g->file, &seen);
   visited_free (&seen);
 }
 
-/* read_makefiles is the chain remake parsed; watch each entry's
+/* read_files is the chain main() parsed; watch each entry's
    directory.  This set is computed once per process: any change here
    triggers re-exec, and the new process recomputes from scratch.  */
 static void
-build_makefile_watch_set (void)
+build_makefile_watch_set (struct watch_backend *wb,
+                          struct goaldep *read_files)
 {
   struct goaldep *g;
-  char *dir, *base, *scratch;
-  struct watched_dir *d;
-
-  for (g = read_makefiles; g; g = g->next)
+  for (g = read_files; g; g = g->next)
     {
+      char *dir, *base;
       if (!g->file || !g->file->name) continue;
-      if (split_path (g->file->name, &dir, &base, &scratch) != 0) continue;
-      d = find_or_add_dir (&mk_dirs, &n_mk_dirs, &cap_mk_dirs, dir, 1);
-      if (d) dir_add_basename (d, base);
-      free (dir); free (base);
+      split_path (g->file->name, &dir, &base);
+      wb_add (wb, dir, base, 1 /* makefile */);
+      free (dir);
+      free (base);
     }
 }
 
@@ -267,23 +231,26 @@ build_makefile_watch_set (void)
 static void
 reset_one (struct file *f, struct visited_set *seen)
 {
+  struct dep *d;
   if (!f) return;
   while (f->renamed) f = f->renamed;
   if (!visited_add (seen, f)) return;
 
+  /* update_goal_chain bumps a global 'considered' counter on entry and
+     compares f->considered to it, so leaving f->considered alone is
+     enough to force re-evaluation.  */
   f->last_mtime = UNKNOWN_MTIME;
   f->mtime_before_update = UNKNOWN_MTIME;
   f->updated = 0;
-  f->considered = 0;
   f->command_state = cs_not_started;
   f->update_status = us_none;
 
-  for (struct dep *d = f->deps; d; d = d->next)
+  for (d = f->deps; d; d = d->next)
     {
       d->changed = 0;
       if (d->file) reset_one (d->file, seen);
     }
-  for (struct dep *d = f->also_make; d; d = d->next)
+  for (d = f->also_make; d; d = d->next)
     if (d->file) reset_one (d->file, seen);
 }
 
@@ -291,152 +258,67 @@ static void
 reset_goal_subgraph (struct goaldep *goals)
 {
   struct visited_set seen;
+  struct goaldep *g;
   visited_init (&seen, 64);
-  for (struct goaldep *g = goals; g; g = g->next)
+  for (g = goals; g; g = g->next)
     if (g->file) reset_one (g->file, &seen);
   visited_free (&seen);
 }
 
-/* Returns 1 if (wd, basename) hits the source set, 2 if makefile set,
-   0 if neither.  Makefile takes precedence on a tie -- a re-exec is a
-   superset of a rebuild.  */
-static int
-classify (int wd, const char *base)
-{
-  for (int i = 0; i < n_mk_dirs; i++)
-    if (mk_dirs[i].wd == wd)
-      for (int j = 0; j < mk_dirs[i].n_basenames; j++)
-        if (strcmp (mk_dirs[i].basenames[j], base) == 0)
-          return 2;
-  for (int i = 0; i < n_src_dirs; i++)
-    if (src_dirs[i].wd == wd)
-      for (int j = 0; j < src_dirs[i].n_basenames; j++)
-        if (strcmp (src_dirs[i].basenames[j], base) == 0)
-          return 1;
-  return 0;
-}
-
-/* Drain inotify events with a debounce.  Returns 1 if a source change
-   (or queue overflow) was seen, 2 if a makefile change was seen
-   (highest wins), 0 if no watched basenames matched (caller should
-   keep waiting), -1 on fatal read error.  Bounded by both DEBOUNCE_MS
-   and DEBOUNCE_MAX_EVENTS.  */
-static int
-wait_and_drain (void)
-{
-  char buf[EVENT_BUF_BYTES] __attribute__((aligned(8)));
-  struct pollfd pfd;
-  int kind = 0;
-  int events_seen = 0;
-  int r;
-
-  pfd.fd = notify_fd;
-  pfd.events = POLLIN;
-  pfd.revents = 0;
-
-  /* Block until first event arrives.  */
-  for (;;)
-    {
-      r = poll (&pfd, 1, -1);
-      if (r < 0)
-        {
-          if (errno == EINTR) return -1;     /* signal: caller decides */
-          OS (error, NILF, _("--watch: poll: %s"), strerror (errno));
-          return -1;
-        }
-      if (pfd.revents & POLLIN) break;
-    }
-
-  /* Then drain with short timeout to coalesce bursts.  */
-  for (;;)
-    {
-      ssize_t len = read (notify_fd, buf, sizeof buf);
-      char *p;
-      if (len < 0)
-        {
-          if (errno == EAGAIN
-#if EAGAIN != EWOULDBLOCK
-              || errno == EWOULDBLOCK
-#endif
-              ) break;
-          if (errno == EINTR) continue;
-          OS (error, NILF, _("--watch: read: %s"), strerror (errno));
-          return -1;
-        }
-      for (p = buf; p < buf + len; )
-        {
-          struct inotify_event *e = (struct inotify_event *) p;
-          if (e->mask & IN_Q_OVERFLOW)
-            return 1;                        /* lost events: force source rebuild */
-          if (e->len > 0)
-            {
-              int k = classify (e->wd, e->name);
-              if (k > kind) kind = k;
-            }
-          p += sizeof (struct inotify_event) + e->len;
-          if (++events_seen >= DEBOUNCE_MAX_EVENTS)
-            return kind;                     /* hard cap */
-        }
-      if (kind == 2) return 2;               /* makefile wins, no need to drain more */
-
-      pfd.revents = 0;
-      r = poll (&pfd, 1, DEBOUNCE_MS);
-      if (r <= 0) break;
-    }
-
-  /* If we got events but none matched watched basenames (e.g. build
-     outputs in the same directory), report kind=0.  The caller's outer
-     loop will go back to poll() and block until the next event, so
-     this does not spin.  */
-  return kind;
-}
-
-static long
-ts_diff_ns (const struct timespec *a, const struct timespec *b)
-{
-  return (a->tv_sec - b->tv_sec) * 1000000000L + (a->tv_nsec - b->tv_nsec);
-}
-
 void
-watch_loop (struct goaldep *goals, int argc, char **argv)
+watch_loop (struct goaldep *goals, struct goaldep *read_files,
+            int argc, char **argv)
 {
-  /* Save argv for re-exec.  argv may live on the stack of main(); we
-     copy pointers, but the strings themselves are stable.  */
-  char **saved_argv = xmalloc ((argc + 1) * sizeof (char *));
+  char **saved_argv;
+  struct watch_backend *wb;
   enum update_status st;
+  intmax_t self_trigger_window_ms;
+  int min_lat;
   int i;
 
+  /* Save argv for re-exec.  argv may live on the stack of main(); we
+     copy pointers, but the strings themselves are stable.  */
+  saved_argv = xmalloc ((argc + 1) * sizeof (char *));
   for (i = 0; i < argc; i++) saved_argv[i] = argv[i];
   saved_argv[argc] = NULL;
 
-  notify_fd = inotify_init1 (IN_CLOEXEC | IN_NONBLOCK);
-  if (notify_fd < 0)
+  wb = wb_init ();
+  if (!wb)
     {
-      OS (fatal, NILF, _("--watch: inotify_init: %s"), strerror (errno));
-      return;
+      free (saved_argv);
+      return;                                /* wb_init already fataled */
     }
 
-  /* Initial build, in-process, exactly as the non-watch path would.  */
+  /* Self-trigger window must be at least one backend tick (otherwise
+     under polling the just-finished build's mtime updates land
+     outside the window and the guard never fires).  */
+  min_lat = wb_min_latency_ms (wb);
+  self_trigger_window_ms = SELF_TRIGGER_WINDOW_MS_FLOOR;
+  if ((intmax_t) min_lat * 2 > self_trigger_window_ms)
+    self_trigger_window_ms = (intmax_t) min_lat * 2;
+
+  /* Initial build, in-process, exactly as the non-watch path would.
+     -p (print_data_base_flag) and other end-of-run actions are
+     honored by die() on the rebuild path; they are *not* honored on
+     the makefile-edit re-exec path (execvp replaces the process
+     image), which mirrors the non-watch behavior of restart.  */
   st = update_goal_chain (goals);
   if (st == us_failed)
     O (error, NILF,
        _("--watch: initial build failed; will retry on next change."));
 
-  build_source_watch_set (goals);
-  build_makefile_watch_set ();
-  clock_gettime (CLOCK_MONOTONIC, &last_build_finished);
-
-  /* Note: -p (print_data_base_flag) is honored on exit via die(),
-     same as the non-watch path.  */
+  build_source_watch_set (wb, goals);
+  build_makefile_watch_set (wb, read_files);
+  last_build_finished_ms = monotonic_ms ();
 
   O (message, 0, _("--watch: waiting for changes (Ctrl-C to stop)..."));
 
   for (;;)
     {
       int kind;
-      struct timespec now;
+      intmax_t now_ms, since_ms;
 
-      kind = wait_and_drain ();
+      kind = wb_wait (wb);
       if (kind < 0)
         {
           /* Signal: let normal signal handling shut us down cleanly.  */
@@ -445,27 +327,34 @@ watch_loop (struct goaldep *goals, int argc, char **argv)
       if (kind == 0)
         continue;                            /* events were not for us */
 
-      clock_gettime (CLOCK_MONOTONIC, &now);
+      now_ms = monotonic_ms ();
 
       if (kind == 2)
         {
-          /* Makefile change: re-exec for full re-parse.  Simpler than
-             the bootstrap re_exec path in main.c -- we have no stdin
-             temp file to preserve and no in-flight makefile rebuild.  */
+          /* Makefile change: re-exec for full re-parse.  Restore the
+             working directory the user invoked us from so that any
+             relative paths in argv (e.g. -C subdir, -f path) and
+             argv[0] itself resolve identically in the new process.  */
           O (message, 0,
              _("--watch: makefile changed, re-executing remake."));
           fflush (stdout);
           fflush (stderr);
-          close (notify_fd);
+          wb_close (wb);
+          if (directory_before_chdir != 0
+              && chdir (directory_before_chdir) < 0)
+            OS (fatal, NILF, _("--watch: chdir before re-exec: %s"),
+                strerror (errno));
           execvp (saved_argv[0], saved_argv);
           OS (fatal, NILF, _("--watch: execvp failed: %s"), strerror (errno));
         }
 
-      /* Inductive-unboundedness guard: if the rebuild that just
-         finished is what triggered this wake (event came within
-         SELF_TRIGGER_WINDOW_NS of the build completing), assume the
-         rebuild touched its own watched outputs.  */
-      if (ts_diff_ns (&now, &last_build_finished) < SELF_TRIGGER_WINDOW_NS)
+      /* Inductive-unboundedness guard: if this event arrived within
+         the self-trigger window of the last build finishing, assume
+         the rebuild touched its own watched outputs.  Negative diffs
+         (clock skew under the gettimeofday fallback) are treated as
+         "long ago" so we do not falsely accuse.  */
+      since_ms = now_ms - last_build_finished_ms;
+      if (since_ms >= 0 && since_ms < self_trigger_window_ms)
         {
           self_trigger_count++;
           if (self_trigger_count == SELF_TRIGGER_WARN)
@@ -487,9 +376,7 @@ watch_loop (struct goaldep *goals, int argc, char **argv)
       st = update_goal_chain (goals);
       if (st == us_failed)
         O (error, NILF, _("--watch: build failed; will retry on next change."));
-      build_source_watch_set (goals);  /* pick up new generated prereqs */
-      clock_gettime (CLOCK_MONOTONIC, &last_build_finished);
+      build_source_watch_set (wb, goals);  /* pick up new generated prereqs */
+      last_build_finished_ms = monotonic_ms ();
     }
 }
-
-#endif /* HAVE_SYS_INOTIFY_H */

--- a/src/watch_inotify.c
+++ b/src/watch_inotify.c
@@ -1,0 +1,265 @@
+/* inotify-based --watch backend for remake.
+Copyright (C) 2026 Free Software Foundation, Inc.
+This file is part of GNU Make / remake.
+
+GNU Make is free software; you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation; either version 3 of the License, or (at your option) any later
+version.
+
+GNU Make is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+#include "makeint.h"
+
+#ifdef HAVE_SYS_INOTIFY_H
+
+#include "debug.h"
+#include "os.h"
+#include "watchbackend.h"
+
+#include <sys/inotify.h>
+#include <unistd.h>
+#include <poll.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+/* Tunables.  Kept conservative; expose later as env vars if needed.  */
+#define DEBOUNCE_MS            50
+#define DEBOUNCE_MAX_EVENTS    10000
+#define EVENT_BUF_BYTES        (64 * 1024)
+
+/* A directory we watch.  We watch the *directory* (not the file) so
+   atomic-replace saves (vim, most editors) don't detach the watch.
+   Each entry tracks the basenames in that directory we care about,
+   so changes to unrelated siblings can be filtered out.  */
+struct watched_dir
+{
+  int wd;                       /* inotify watch descriptor */
+  char *path;                   /* directory path (owned) */
+  char **basenames;             /* names of files we care about */
+  int n_basenames;
+  int cap_basenames;
+};
+
+struct watch_backend
+{
+  int notify_fd;
+  struct watched_dir *src_dirs;
+  int n_src_dirs, cap_src_dirs;
+  struct watched_dir *mk_dirs;
+  int n_mk_dirs, cap_mk_dirs;
+};
+
+static void
+dir_add_basename (struct watched_dir *d, const char *base)
+{
+  int i;
+  for (i = 0; i < d->n_basenames; i++)
+    if (strcmp (d->basenames[i], base) == 0) return;
+  if (d->n_basenames == d->cap_basenames)
+    {
+      d->cap_basenames = d->cap_basenames ? d->cap_basenames * 2 : 4;
+      d->basenames = xrealloc (d->basenames,
+                               d->cap_basenames * sizeof (char *));
+    }
+  d->basenames[d->n_basenames++] = xstrdup (base);
+}
+
+static struct watched_dir *
+find_or_add_dir (struct watch_backend *wb, struct watched_dir **arr,
+                 int *n, int *cap, const char *path)
+{
+  /* CLOSE_WRITE coalesces in-progress writes; MOVED_TO catches editor
+     atomic-replace; CREATE/DELETE catch newly-added/removed prereqs.
+     IN_MODIFY and IN_ATTRIB are intentionally omitted -- they fire
+     mid-write and on metadata-only changes, producing spurious
+     wakeups.  */
+  const uint32_t mask = IN_CLOSE_WRITE | IN_MOVED_TO | IN_CREATE | IN_DELETE;
+  struct watched_dir *d;
+  int i;
+
+  for (i = 0; i < *n; i++)
+    if (strcmp ((*arr)[i].path, path) == 0)
+      return &(*arr)[i];
+
+  if (*n == *cap)
+    {
+      *cap = *cap ? *cap * 2 : 8;
+      *arr = xrealloc (*arr, *cap * sizeof (struct watched_dir));
+    }
+  d = &(*arr)[*n];
+  memset (d, 0, sizeof (*d));
+  d->path = xstrdup (path);
+  d->wd = inotify_add_watch (wb->notify_fd, path, mask);
+  if (d->wd < 0)
+    {
+      OSS (error, NILF, _("--watch: cannot watch directory '%s': %s"),
+           path, strerror (errno));
+      free (d->path);
+      d->path = NULL;
+      return NULL;
+    }
+  (*n)++;
+  return d;
+}
+
+struct watch_backend *
+wb_init (void)
+{
+  struct watch_backend *wb = xcalloc (sizeof (*wb));
+  wb->notify_fd = inotify_init1 (IN_CLOEXEC | IN_NONBLOCK);
+  if (wb->notify_fd < 0)
+    {
+      OS (fatal, NILF, _("--watch: inotify_init: %s"), strerror (errno));
+      /* unreachable */
+      free (wb);
+      return NULL;
+    }
+  return wb;
+}
+
+int
+wb_add (struct watch_backend *wb, const char *dir, const char *base,
+        int is_makefile)
+{
+  struct watched_dir **arr  = is_makefile ? &wb->mk_dirs    : &wb->src_dirs;
+  int *n                    = is_makefile ? &wb->n_mk_dirs  : &wb->n_src_dirs;
+  int *cap                  = is_makefile ? &wb->cap_mk_dirs: &wb->cap_src_dirs;
+  struct watched_dir *d = find_or_add_dir (wb, arr, n, cap, dir);
+  if (!d) return -1;
+  dir_add_basename (d, base);
+  return 0;
+}
+
+/* Returns 1 if (wd, basename) hits the source set, 2 if makefile set,
+   0 if neither.  Makefile takes precedence on a tie -- a re-exec is a
+   superset of a rebuild.  */
+static int
+classify (struct watch_backend *wb, int wd, const char *base)
+{
+  int i, j;
+  for (i = 0; i < wb->n_mk_dirs; i++)
+    if (wb->mk_dirs[i].wd == wd)
+      for (j = 0; j < wb->mk_dirs[i].n_basenames; j++)
+        if (strcmp (wb->mk_dirs[i].basenames[j], base) == 0)
+          return 2;
+  for (i = 0; i < wb->n_src_dirs; i++)
+    if (wb->src_dirs[i].wd == wd)
+      for (j = 0; j < wb->src_dirs[i].n_basenames; j++)
+        if (strcmp (wb->src_dirs[i].basenames[j], base) == 0)
+          return 1;
+  return 0;
+}
+
+int
+wb_wait (struct watch_backend *wb)
+{
+  char buf[EVENT_BUF_BYTES] __attribute__((aligned(8)));
+  struct pollfd pfd;
+  int kind = 0;
+  int events_seen = 0;
+  int r;
+
+  pfd.fd = wb->notify_fd;
+  pfd.events = POLLIN;
+  pfd.revents = 0;
+
+  /* Block until first event arrives.  */
+  for (;;)
+    {
+      r = poll (&pfd, 1, -1);
+      if (r < 0)
+        {
+          if (errno == EINTR) return -1;     /* signal: caller decides */
+          OS (error, NILF, _("--watch: poll: %s"), strerror (errno));
+          return -1;
+        }
+      if (pfd.revents & POLLIN) break;
+    }
+
+  /* Then drain with short timeout to coalesce bursts.  */
+  for (;;)
+    {
+      ssize_t len = read (wb->notify_fd, buf, sizeof (buf));
+      char *p;
+      if (len < 0)
+        {
+          if (errno == EAGAIN
+#if EAGAIN != EWOULDBLOCK
+              || errno == EWOULDBLOCK
+#endif
+              ) break;
+          if (errno == EINTR) continue;
+          OS (error, NILF, _("--watch: read: %s"), strerror (errno));
+          return -1;
+        }
+      for (p = buf; p < buf + len; )
+        {
+          struct inotify_event *e = (struct inotify_event *) p;
+          if (e->mask & IN_Q_OVERFLOW)
+            return 1;                        /* lost events: force source rebuild */
+          if (e->len > 0)
+            {
+              int k = classify (wb, e->wd, e->name);
+              if (k > kind) kind = k;
+            }
+          p += sizeof (struct inotify_event) + e->len;
+          if (++events_seen >= DEBOUNCE_MAX_EVENTS)
+            return kind;                     /* hard cap */
+        }
+      if (kind == 2) return 2;               /* makefile wins, no need to drain more */
+
+      pfd.revents = 0;
+      r = poll (&pfd, 1, DEBOUNCE_MS);
+      if (r <= 0) break;
+    }
+
+  /* If we got events but none matched watched basenames (e.g. build
+     outputs in the same directory), report kind=0.  The caller's outer
+     loop will go back to poll() and block until the next event, so
+     this does not spin.  */
+  return kind;
+}
+
+int
+wb_min_latency_ms (const struct watch_backend *wb)
+{
+  (void) wb;
+  /* Inotify reports events in milliseconds; the debounce is the only
+     intentional delay we add.  */
+  return DEBOUNCE_MS;
+}
+
+void
+wb_close (struct watch_backend *wb)
+{
+  int i, j;
+  if (!wb) return;
+  if (wb->notify_fd >= 0) close (wb->notify_fd);
+  for (i = 0; i < wb->n_src_dirs; i++)
+    {
+      free (wb->src_dirs[i].path);
+      for (j = 0; j < wb->src_dirs[i].n_basenames; j++)
+        free (wb->src_dirs[i].basenames[j]);
+      free (wb->src_dirs[i].basenames);
+    }
+  free (wb->src_dirs);
+  for (i = 0; i < wb->n_mk_dirs; i++)
+    {
+      free (wb->mk_dirs[i].path);
+      for (j = 0; j < wb->mk_dirs[i].n_basenames; j++)
+        free (wb->mk_dirs[i].basenames[j]);
+      free (wb->mk_dirs[i].basenames);
+    }
+  free (wb->mk_dirs);
+  free (wb);
+}
+
+#endif /* HAVE_SYS_INOTIFY_H */

--- a/src/watch_poll.c
+++ b/src/watch_poll.c
@@ -1,0 +1,247 @@
+/* stat()-based polling --watch backend for remake.
+Copyright (C) 2026 Free Software Foundation, Inc.
+This file is part of GNU Make / remake.
+
+GNU Make is free software; you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation; either version 3 of the License, or (at your option) any later
+version.
+
+GNU Make is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+/* This backend is selected when no native fs-event API is available.
+   It is the universal fallback: every platform that has stat(2) can
+   use --watch through this backend.  Linux / Cygwin builds prefer
+   watch_inotify.c instead; pass --without-inotify to configure to
+   route through here for testing.
+
+   We compare the previous and current stat() of every watched path on
+   each tick.  A path is considered "changed" if mtime, size, or inode
+   differs (the last covers atomic-replace editor saves).  Granularity
+   is set by env MAKE_WATCH_POLL_INTERVAL (milliseconds; default
+   1000).  */
+
+#include "makeint.h"
+
+#ifndef HAVE_SYS_INOTIFY_H
+
+#include "debug.h"
+#include "os.h"
+#include "watchbackend.h"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+
+#ifdef HAVE_NANOSLEEP
+# include <time.h>
+#else
+/* Fallback: select(2) with a finite timeout is the most portable
+   "sleep with sub-second precision" call.  POSIX guarantees it on
+   every platform GNU Make builds on.  */
+# include <sys/select.h>
+#endif
+
+#define DEFAULT_POLL_MS  1000
+#define MIN_POLL_MS      50
+#define MAX_POLL_MS      60000
+
+struct watched_entry
+{
+  char *path;                   /* full path, owned */
+  struct stat last;             /* last seen stat; valid iff have_stat */
+  int have_stat;                /* 0 if path did not exist last tick */
+  int is_makefile;
+};
+
+struct watch_backend
+{
+  struct watched_entry *entries;
+  int n, cap;
+  int poll_ms;
+};
+
+static int
+parse_poll_ms (void)
+{
+  const char *s = getenv ("MAKE_WATCH_POLL_INTERVAL");
+  char *end;
+  long v;
+
+  if (!s || !*s) return DEFAULT_POLL_MS;
+  v = strtol (s, &end, 10);
+  if (*end != '\0' || v < MIN_POLL_MS || v > MAX_POLL_MS)
+    {
+      OSN (error, NILF,
+           _("--watch: ignoring bad MAKE_WATCH_POLL_INTERVAL='%s' (using %d ms)"),
+           s, DEFAULT_POLL_MS);
+      return DEFAULT_POLL_MS;
+    }
+  return (int) v;
+}
+
+struct watch_backend *
+wb_init (void)
+{
+  struct watch_backend *wb = xcalloc (sizeof (*wb));
+  wb->poll_ms = parse_poll_ms ();
+  return wb;
+}
+
+int
+wb_add (struct watch_backend *wb, const char *dir, const char *base,
+        int is_makefile)
+{
+  size_t dlen = strlen (dir);
+  size_t blen = strlen (base);
+  /* +2: one for the separator, one for NUL.  */
+  char *full = xmalloc (dlen + blen + 2);
+  int sep = (dlen > 0 && dir[dlen - 1] != '/');
+  struct watched_entry *e;
+  int i;
+
+  if (dlen == 1 && dir[0] == '.')
+    {
+      /* Strip leading "./" so two callers passing "./foo" and "foo"
+         end up identical and we don't double-watch.  */
+      memcpy (full, base, blen + 1);
+    }
+  else
+    {
+      memcpy (full, dir, dlen);
+      if (sep) full[dlen++] = '/';
+      memcpy (full + dlen, base, blen + 1);
+    }
+
+  /* Dedup against existing entries.  Linear scan is fine: the goal
+     subgraph is rebuilt periodically and is typically small.  */
+  for (i = 0; i < wb->n; i++)
+    if (wb->entries[i].is_makefile == is_makefile
+        && strcmp (wb->entries[i].path, full) == 0)
+      {
+        free (full);
+        return 0;
+      }
+
+  if (wb->n == wb->cap)
+    {
+      wb->cap = wb->cap ? wb->cap * 2 : 64;
+      wb->entries = xrealloc (wb->entries,
+                              wb->cap * sizeof (struct watched_entry));
+    }
+  e = &wb->entries[wb->n++];
+  e->path = full;
+  e->is_makefile = is_makefile;
+  e->have_stat = 0;
+  if (stat (full, &e->last) == 0)
+    e->have_stat = 1;
+  return 0;
+}
+
+/* Returns 1 if e changed since last call (and updates e->last), 0 if
+   not.  A vanished path counts as change.  A reappeared path counts as
+   change.  */
+static int
+entry_changed (struct watched_entry *e)
+{
+  struct stat st;
+  int rc = stat (e->path, &st);
+  if (rc != 0)
+    {
+      if (e->have_stat)
+        {
+          e->have_stat = 0;
+          return 1;                          /* existed -> gone */
+        }
+      return 0;                              /* still missing */
+    }
+  if (!e->have_stat)
+    {
+      e->have_stat = 1;
+      e->last = st;
+      return 1;                              /* gone -> exists */
+    }
+  if (st.st_mtime != e->last.st_mtime
+      || st.st_size  != e->last.st_size
+      || st.st_ino   != e->last.st_ino)
+    {
+      e->last = st;
+      return 1;
+    }
+  return 0;
+}
+
+/* Sleep up to MS milliseconds.  Returns 0 if the sleep finished, or
+   -1 if interrupted by a signal -- in which case the caller should
+   propagate the interruption upward (so Ctrl-C does not feel
+   sluggish under the poll backend's tick).  */
+static int
+sleep_ms (int ms)
+{
+#ifdef HAVE_NANOSLEEP
+  struct timespec req;
+  req.tv_sec  = ms / 1000;
+  req.tv_nsec = (ms % 1000) * 1000000L;
+  if (nanosleep (&req, NULL) < 0)
+    return -1;                          /* signal or other error */
+  return 0;
+#else
+  struct timeval tv;
+  tv.tv_sec  = ms / 1000;
+  tv.tv_usec = (ms % 1000) * 1000;
+  if (select (0, NULL, NULL, NULL, &tv) < 0)
+    return -1;
+  return 0;
+#endif
+}
+
+int
+wb_wait (struct watch_backend *wb)
+{
+  int kind = 0;
+  int i;
+
+  /* Sleep, then sweep.  We sleep first so the caller's just-finished
+     build has a beat to settle.  Propagate EINTR upward as -1 so
+     Ctrl-C is responsive even mid-tick.  */
+  if (sleep_ms (wb->poll_ms) < 0)
+    return -1;
+
+  for (i = 0; i < wb->n; i++)
+    {
+      if (entry_changed (&wb->entries[i]))
+        {
+          int k = wb->entries[i].is_makefile ? 2 : 1;
+          if (k > kind) kind = k;
+          if (kind == 2) break;              /* makefile wins */
+        }
+    }
+  return kind;                               /* 0 means no change this tick */
+}
+
+int
+wb_min_latency_ms (const struct watch_backend *wb)
+{
+  return wb->poll_ms;
+}
+
+void
+wb_close (struct watch_backend *wb)
+{
+  int i;
+  if (!wb) return;
+  for (i = 0; i < wb->n; i++)
+    free (wb->entries[i].path);
+  free (wb->entries);
+  free (wb);
+}
+
+#endif /* !HAVE_SYS_INOTIFY_H */

--- a/src/watchbackend.h
+++ b/src/watchbackend.h
@@ -1,0 +1,59 @@
+/* File-system watch backend interface for remake's --watch.
+Copyright (C) 2026 Free Software Foundation, Inc.
+This file is part of GNU Make / remake.
+
+GNU Make is free software; you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation; either version 3 of the License, or (at your option) any later
+version.
+
+GNU Make is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+/* The frontend in watch.c walks the goal subgraph and feeds each watched
+   (directory, basename) pair to a backend through this interface.
+
+   Exactly one backend is selected at compile time:
+
+     HAVE_SYS_INOTIFY_H  -> watch_inotify.c   (Linux, Cygwin; can be
+                            forced off via configure --without-inotify)
+     else                -> watch_poll.c      (universal fallback,
+                            stat()-based)
+
+   Future per-platform backends (kqueue on the BSDs / macOS,
+   ReadDirectoryChangesW on Windows) plug in here through the same
+   interface, selected ahead of polling when their AC_CHECK_HEADERS
+   probes succeed.
+
+   wb_wait waits for a change.  On the inotify backend it blocks until
+   the kernel reports an event; on the polling backend it sleeps up to
+   one tick and then returns whatever it found (possibly nothing).  It
+   returns:
+       2 = a watched makefile changed (caller should re-exec),
+       1 = a watched source changed (caller should rebuild),
+       0 = wake-up but no relevant change (caller should call again),
+      -1 = signal received or fatal error (caller should die).
+
+   wb_min_latency_ms returns a backend-specific upper bound on how
+   long after a build finishes a "self-triggered" event might still
+   look like a fresh user edit.  For inotify this is small (events
+   stream within milliseconds); for polling it is one tick.  The
+   frontend uses it to size the self-trigger window.  */
+
+#ifndef WATCHBACKEND_H
+#define WATCHBACKEND_H 1
+
+struct watch_backend;
+
+struct watch_backend *wb_init (void);
+int  wb_add (struct watch_backend *wb, const char *dir, const char *base,
+             int is_makefile);
+int  wb_wait (struct watch_backend *wb);
+int  wb_min_latency_ms (const struct watch_backend *wb);
+void wb_close (struct watch_backend *wb);
+
+#endif /* WATCHBACKEND_H */

--- a/tests/scripts/options/dash-watch
+++ b/tests/scripts/options/dash-watch
@@ -1,0 +1,169 @@
+#                                                                    -*-perl-*-
+
+$description = "Test make --watch (incremental rebuild on file-system changes).\n";
+
+$details = "Verify that --watch:
+1. is incompatible with -t (rejected at startup).
+2. only watches transitive prerequisites of command-line goals.
+3. does not self-trigger when a recipe writes its own output.
+4. re-execs the make process when a makefile changes.
+The watch loop tests background make, edit a source, sleep, then kill make,
+and check the captured log.";
+
+# Skip on platforms without inotify.  We probe by asking --watch to do
+# something tiny: a make built without HAVE_SYS_INOTIFY_H prints a fatal
+# error the moment --watch is requested.
+{
+    my $probe = `$make_path --watch -v 2>&1`;
+    if ($probe =~ /inotify is not available/) {
+        return -1;
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test 15: --watch with -t is rejected at startup (no background needed).
+
+run_make_test('
+hello: ; @echo built
+',
+              '--watch -t hello',
+              "#MAKE#: *** --watch is incompatible with -t/--touch.  Stop.",
+              512);
+
+# ---------------------------------------------------------------------------
+# Helper: run "make --watch GOALS" in background, perform $editor (a shell
+# snippet) after $delay1 seconds, wait $delay2, then kill make.  Returns
+# captured stdout+stderr as a single string.
+
+sub run_watch {
+    my ($makestring, $goals, $editor, $delay1, $delay2) = @_;
+    my $mf = &get_tmpfile();
+    open(my $fh, '>', $mf) or die "open $mf: $!";
+    print $fh $makestring;
+    close($fh);
+
+    my $log = "$mf.watchlog";
+    my $script = qq{
+        ( $make_path -f $mf --watch $goals > $log 2>&1 ) &
+        WPID=\$!
+        sleep $delay1
+        $editor
+        sleep $delay2
+        kill \$WPID 2>/dev/null
+        wait 2>/dev/null
+        true
+    };
+    system('sh', '-c', $script);
+
+    my $out = '';
+    if (open($fh, '<', $log)) {
+        local $/;
+        $out = <$fh>;
+        close($fh);
+    }
+    unlink($log);
+    return $out;
+}
+
+sub count_str {
+    my ($hay, $needle) = @_;
+    my $n = 0;
+    $n++ while $hay =~ /\Q$needle\E/g;
+    return $n;
+}
+
+# Mark a test as run, with pass/fail derived from a boolean.
+sub watch_check {
+    my ($label, $ok, $out) = @_;
+    ++$tests_run;
+    if ($ok) {
+        ++$tests_passed;
+        print "ok: $label\n" if $debug;
+    } else {
+        $suite_passed = 0;
+        print "FAIL: $label\nCaptured output:\n$out\n";
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: rebuild does not self-trigger.  Recipe writes its own output;
+# after exactly one edit there must be exactly one rebuild, not a cascade.
+
+unlink('hello', 'hello.c');
+open(my $fh, '>', 'hello.c') or die;
+print $fh "int main(void){return 0;}\n";
+close($fh);
+
+my $out = run_watch(
+    "hello: hello.c\n\t\@cc -o \$\@ \$<\n",
+    'hello',
+    q{ printf 'int main(void){return 1;}\n' > hello.c },
+    1, 2);
+
+my $rebuilds = count_str($out, '--watch: change detected, rebuilding.');
+watch_check("self-trigger guard: 1 edit -> 1 rebuild (got $rebuilds)",
+            $rebuilds == 1, $out);
+
+unlink('hello', 'hello.c');
+
+# ---------------------------------------------------------------------------
+# Test 5: goals not on the command line are not watched.  Build "a" only;
+# edit "b.in"; expect no rebuild.
+
+unlink('a', 'b', 'a.in', 'b.in');
+open($fh, '>', 'a.in') or die; print $fh "a\n"; close($fh);
+open($fh, '>', 'b.in') or die; print $fh "b\n"; close($fh);
+
+$out = run_watch(
+    "a: a.in\n\t\@cp \$< \$\@\nb: b.in\n\t\@cp \$< \$\@\n",
+    'a',
+    q{ echo new > b.in },
+    1, 2);
+
+$rebuilds = count_str($out, '--watch: change detected, rebuilding.');
+watch_check("scoped watch set: edit to unwatched prerequisite -> 0 rebuilds (got $rebuilds)",
+            $rebuilds == 0, $out);
+
+unlink('a', 'b', 'a.in', 'b.in');
+
+# ---------------------------------------------------------------------------
+# Test 6: editing the makefile triggers re-exec.
+
+unlink('out', 'out.in');
+open($fh, '>', 'out.in') or die; print $fh "x\n"; close($fh);
+
+# Drive this one manually because the editor edits the makefile itself.
+my $mf = &get_tmpfile();
+open($fh, '>', $mf) or die;
+print $fh "out: out.in\n\t\@cp \$< \$\@\n";
+close($fh);
+
+my $log = "$mf.watchlog";
+my $script = qq{
+    ( $make_path -f $mf --watch out > $log 2>&1 ) &
+    WPID=\$!
+    sleep 1
+    printf 'out: out.in\\n\\t\@echo edited; cp \$< \$\@\\n' > $mf
+    sleep 2
+    kill \$WPID 2>/dev/null
+    wait 2>/dev/null
+    true
+};
+system('sh', '-c', $script);
+
+$out = '';
+if (open($fh, '<', $log)) { local $/; $out = <$fh>; close($fh); }
+unlink($log);
+
+my $matched_reexec = ($out =~ /--watch: makefile changed, re-executing remake\./) ? 1 : 0;
+watch_check("makefile edit triggers re-exec",
+            $matched_reexec,
+            $out);
+
+unlink('out', 'out.in');
+
+1;
+
+### Local Variables:
+### eval: (setq whitespace-action (delq 'auto-cleanup whitespace-action))
+### End:


### PR DESCRIPTION
Stay running after the initial build, watch the transitive prerequisite set of the named goals via Linux inotify, and remake affected targets when a watched file changes.  When a makefile that was read changes, re-exec with the original argv so makefiles are re-parsed cleanly.

The watch set is scoped: only files reachable from the command-line goals (or default goal) are watched, so edits to unrelated files do not trigger rebuilds.  Files with recipes (build outputs) are excluded from the watch set to prevent the recipe's own output from re-triggering the loop.

--watch is rejected at startup when combined with -t/--touch.  On platforms without <sys/inotify.h>, the option polls with `stat`.

Tests in tests/scripts/options/dash-watch cover: option-conflict rejection, single-edit/single-rebuild self-trigger guard, scoped watch set (edits to off-goal prerequisites are ignored), and makefile-edit re-exec.  The test gates on inotify availability and skips otherwise.