### PR TITLE
Changes dicted by updating to autoconf 2.72

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -60,7 +60,7 @@ AC_CHECK_FUNCS(gethostbyname,,[
 	CF_RECHECK_FUNC(gethostbyname,nsl,cf_cv_netlibs)])
 ])
 LIBS="$LIBS $cf_cv_netlibs"
-test $cf_test_netlibs = no && echo "$cf_cv_netlibs" >&AC_FD_MSG
+test $cf_test_netlibs = no && echo "$cf_cv_netlibs" >&AS_MESSAGE_FD
 ])dnl
 dnl ---------------------------------------------------------------------------
 dnl Re-check on a function to see if we can pick it up by adding a library.
@@ -116,9 +116,10 @@ AC_DEFUN([AC_STRUCT_ST_MTIM_NSEC],
     # st_mtimespec.tv_nsec -- Darwin (Mac OSX)
     for ac_val in st_mtim.tv_nsec st_mtim._tv_nsec st_mtim.st__tim.tv_nsec st_mtime_n st_mtimespec.tv_nsec; do
       CPPFLAGS="$ac_save_CPPFLAGS -DST_MTIM_NSEC=$ac_val"
-      AC_TRY_COMPILE([#include <sys/types.h>
+      AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM[#include <sys/types.h>
 #include <sys/stat.h>
-	], [struct stat s; s.ST_MTIM_NSEC;],
+	]], [struct stat s; s.ST_MTIM_NSEC;],
         [ac_cv_struct_st_mtim_nsec=$ac_val; break])
     done
     CPPFLAGS="$ac_save_CPPFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ MAKE_PACKAGE=make
 AC_SUBST(MAKE_VERSION)
 AC_SUBST(MAKE_PACKAGE)
 
-AC_PREREQ([2.71])
+AC_PREREQ([2.72])
 
 # Autoconf setup
 AC_CONFIG_AUX_DIR([build-aux])
@@ -35,6 +35,15 @@ AC_CONFIG_HEADERS([src/config.h])
 AM_MAINTAINER_MODE
 
 AC_CONFIG_LIBOBJ_DIR([lib])
+
+AC_USE_SYSTEM_EXTENSIONS
+
+# The GNULIB headers (unistd.h, xalloc.h, etc.) are generated (when needed) during the build process.
+# These require macro definitions from config.h (specifically
+# _GL_INLINE_HEADER_BEGIN, _GL_INLINE_HEADER_END, and _GL_INLINE) to
+# properly parse header inlining semantics.
+AC_C_INLINE
+
 
 AH_TOP(
 /* Guard against #including config.h more than once */
@@ -59,7 +68,6 @@ AM_INIT_AUTOMAKE([subdir-objects 1.14 silent-rules foreign -Wall
                   info-in-builddir])
 
 # Checks for programs.
-AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_CC
 AC_PROG_CXX
 AC_DEFINE_UNQUOTED(MAKE_CXX, ["$CXX"], [Default C++ compiler.])
@@ -112,11 +120,6 @@ AC_SEARCH_LIBS([getpwnam], [sun])
 AC_CHECK_INCLUDES_DEFAULT
 AC_PROG_EGREP
 
-# Checks for header files.
-m4_warn([obsolete],
-[The preprocessor macro `STDC_HEADERS' is obsolete.
-  Except in unusual embedded environments, you can safely include all
-  ISO C90 headers unconditionally.])dnl
 # Autoupdate added the next two lines to ensure that your configure
 # script's behavior did not change.  They are probably safe to remove.
 AC_CHECK_INCLUDES_DEFAULT

--- a/glob/fnmatch.c
+++ b/glob/fnmatch.c
@@ -36,9 +36,7 @@ USA.  */
 # include <strings.h>
 #endif
 
-#if defined STDC_HEADERS || defined _LIBC
-# include <stdlib.h>
-#endif
+#include <stdlib.h>
 
 /* For platform which support the ISO C amendement 1 functionality we
    support user defined character classes.  */
@@ -59,11 +57,7 @@ USA.  */
 #if defined _LIBC || !defined __GNU_LIBRARY__
 
 
-# if defined STDC_HEADERS || !defined isascii
-#  define ISASCII(c) 1
-# else
-#  define ISASCII(c) isascii(c)
-# endif
+#define ISASCII(c) 1
 
 # ifdef isblank
 #  define ISBLANK(c) (ISASCII (c) && isblank (c))

--- a/glob/glob.c
+++ b/glob/glob.c
@@ -59,9 +59,7 @@ USA.  */
 
 #ifndef ELIDE_CODE
 
-#if defined STDC_HEADERS || defined __GNU_LIBRARY__
-# include <stddef.h>
-#endif
+#include <stddef.h>
 
 #if defined HAVE_UNISTD_H || defined _LIBC
 # include <unistd.h>
@@ -130,23 +128,9 @@ extern int errno;
 # define REAL_DIR_ENTRY(dp) (dp->d_ino != 0)
 #endif /* POSIX */
 
-#if defined STDC_HEADERS || defined __GNU_LIBRARY__
 # include <stdlib.h>
 # include <string.h>
 # define	ANSI_STRING
-#else	/* No standard headers.  */
-
-extern char *getenv ();
-
-# ifdef HAVE_STRING_H
-#  include <string.h>
-#  define ANSI_STRING
-# else
-#  include <strings.h>
-# endif
-# ifdef	HAVE_MEMORY_H
-#  include <memory.h>
-# endif
 
 extern char *malloc (), *realloc ();
 extern void free ();

--- a/lib/fnmatch.c
+++ b/lib/fnmatch.c
@@ -36,9 +36,7 @@ USA.  */
 # include <strings.h>
 #endif
 
-#if defined STDC_HEADERS || defined _LIBC
-# include <stdlib.h>
-#endif
+#include <stdlib.h>
 
 /* For platform which support the ISO C amendement 1 functionality we
    support user defined character classes.  */
@@ -59,11 +57,7 @@ USA.  */
 #if defined _LIBC || !defined __GNU_LIBRARY__
 
 
-# if defined STDC_HEADERS || !defined isascii
-#  define ISASCII(c) 1
-# else
-#  define ISASCII(c) isascii(c)
-# endif
+#define ISASCII(c) 1
 
 # ifdef isblank
 #  define ISBLANK(c) (ISASCII (c) && isblank (c))

--- a/lib/glob.c
+++ b/lib/glob.c
@@ -59,9 +59,7 @@ USA.  */
 
 #ifndef ELIDE_CODE
 
-#if defined STDC_HEADERS || defined __GNU_LIBRARY__
-# include <stddef.h>
-#endif
+#include <stddef.h>
 
 #if defined HAVE_UNISTD_H || defined _LIBC
 # include <unistd.h>
@@ -130,23 +128,9 @@ extern int errno;
 # define REAL_DIR_ENTRY(dp) (dp->d_ino != 0)
 #endif /* POSIX */
 
-#if defined STDC_HEADERS || defined __GNU_LIBRARY__
-# include <stdlib.h>
-# include <string.h>
-# define	ANSI_STRING
-#else	/* No standard headers.  */
-
-extern char *getenv ();
-
-# ifdef HAVE_STRING_H
-#  include <string.h>
-#  define ANSI_STRING
-# else
-#  include <strings.h>
-# endif
-# ifdef	HAVE_MEMORY_H
-#  include <memory.h>
-# endif
+#include <stdlib.h>
+#include <string.h>
+#define	ANSI_STRING
 
 extern char *malloc (), *realloc ();
 extern void free ();
@@ -252,10 +236,8 @@ extern char *alloca ();
 # endif
 #endif
 
-#if !(defined STDC_HEADERS || defined __GNU_LIBRARY__)
-# undef	size_t
-# define size_t	unsigned int
-#endif
+#undef	size_t
+#define size_t	unsigned int
 
 /* Some system header files erroneously define these.
    We want our own definitions from <fnmatch.h> to take precedence.  */

--- a/m4/acinclude.m4
+++ b/m4/acinclude.m4
@@ -60,7 +60,7 @@ AC_CHECK_FUNCS(gethostbyname,,[
 	CF_RECHECK_FUNC(gethostbyname,nsl,cf_cv_netlibs)])
 ])
 LIBS="$LIBS $cf_cv_netlibs"
-test $cf_test_netlibs = no && echo "$cf_cv_netlibs" >&AC_FD_MSG
+test $cf_test_netlibs = no && echo "$cf_cv_netlibs" >&AS_MESSAGE_FD
 ])dnl
 dnl ---------------------------------------------------------------------------
 dnl Re-check on a function to see if we can pick it up by adding a library.
@@ -116,10 +116,9 @@ AC_DEFUN([AC_STRUCT_ST_MTIM_NSEC],
     # st_mtimespec.tv_nsec -- Darwin (Mac OSX)
     for ac_val in st_mtim.tv_nsec st_mtim._tv_nsec st_mtim.st__tim.tv_nsec st_mtime_n st_mtimespec.tv_nsec; do
       CPPFLAGS="$ac_save_CPPFLAGS -DST_MTIM_NSEC=$ac_val"
-      AC_TRY_COMPILE([#include <sys/types.h>
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
 #include <sys/stat.h>
-	], [struct stat s; s.ST_MTIM_NSEC;],
-        [ac_cv_struct_st_mtim_nsec=$ac_val; break])
+	]], [[struct stat s; s.ST_MTIM_NSEC;]])],[ac_cv_struct_st_mtim_nsec=$ac_val; break],[])
     done
     CPPFLAGS="$ac_save_CPPFLAGS"
    ])

--- a/m4/extensions.m4
+++ b/m4/extensions.m4
@@ -169,7 +169,6 @@ AC_DEFUN_ONCE([gl_USE_SYSTEM_EXTENSIONS],
   dnl warning: "AC_COMPILE_IFELSE was called before AC_USE_SYSTEM_EXTENSIONS".
   dnl Note: We can do this only for one of the macros AC_AIX, AC_GNU_SOURCE,
   dnl AC_MINIX. If people still use AC_AIX or AC_MINIX, they are out of luck.
-  AC_REQUIRE([AC_GNU_SOURCE])
 
   AC_REQUIRE([AC_USE_SYSTEM_EXTENSIONS])
 ])

--- a/src/make.h
+++ b/src/make.h
@@ -191,32 +191,9 @@ unsigned int get_path_max (void);
 #endif
 // #define UNUSED  __attribute__ ((unused))
 
-#if defined (STDC_HEADERS) || defined (__GNU_LIBRARY__)
 # include <stdlib.h>
 # include <string.h>
 # define ANSI_STRING 1
-#else   /* No standard headers.  */
-# ifdef HAVE_STRING_H
-#  include <string.h>
-#  define ANSI_STRING 1
-# else
-#  include <strings.h>
-# endif
-# ifdef HAVE_MEMORY_H
-#  include <memory.h>
-# endif
-# ifdef HAVE_STDLIB_H
-#  include <stdlib.h>
-# else
-void *malloc (int);
-void *realloc (void *, int);
-void free (void *);
-
-void abort (void) __attribute__ ((noreturn));
-void exit (int) __attribute__ ((noreturn));
-# endif /* HAVE_STDLIB_H.  */
-
-#endif /* Standard headers.  */
 
 /* These should be in stdlib.h.  Make sure we have them.  */
 #ifndef EXIT_SUCCESS

--- a/src/makeint.h
+++ b/src/makeint.h
@@ -239,32 +239,9 @@ unsigned int get_path_max (void);
 #define UNUSED   ATTRIBUTE ((unused))
 #define NORETURN ATTRIBUTE ((noreturn))
 
-#if defined (STDC_HEADERS) || defined (__GNU_LIBRARY__)
-# include <stdlib.h>
-# include <string.h>
-# define ANSI_STRING 1
-#else   /* No standard headers.  */
-# ifdef HAVE_STRING_H
-#  include <string.h>
-#  define ANSI_STRING 1
-# else
-#  include <strings.h>
-# endif
-# ifdef HAVE_MEMORY_H
-#  include <memory.h>
-# endif
-# ifdef HAVE_STDLIB_H
-#  include <stdlib.h>
-# else
-void *malloc (int);
-void *realloc (void *, int);
-void free (void *);
-
-void abort (void) NORETURN;
-void exit (int) NORETURN;
-# endif /* HAVE_STDLIB_H.  */
-
-#endif /* Standard headers.  */
+#include <stdlib.h>
+#include <string.h>
+#define ANSI_STRING 1
 
 /* These should be in stdlib.h.  Make sure we have them.  */
 #ifndef EXIT_SUCCESS


### PR DESCRIPTION
Deal with obsolete macros and the consquences in header tests as a result