### PR TITLE
autoconf 2.71 warning-inspired changes

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -60,7 +60,7 @@ AC_CHECK_FUNCS(gethostbyname,,[
 	CF_RECHECK_FUNC(gethostbyname,nsl,cf_cv_netlibs)])
 ])
 LIBS="$LIBS $cf_cv_netlibs"
-test $cf_test_netlibs = no && echo "$cf_cv_netlibs" >&AC_FD_MSG
+test $cf_test_netlibs = no && echo "$cf_cv_netlibs" >&AS_MESSAGE_FD
 ])dnl
 dnl ---------------------------------------------------------------------------
 dnl Re-check on a function to see if we can pick it up by adding a library.
@@ -116,9 +116,10 @@ AC_DEFUN([AC_STRUCT_ST_MTIM_NSEC],
     # st_mtimespec.tv_nsec -- Darwin (Mac OSX)
     for ac_val in st_mtim.tv_nsec st_mtim._tv_nsec st_mtim.st__tim.tv_nsec st_mtime_n st_mtimespec.tv_nsec; do
       CPPFLAGS="$ac_save_CPPFLAGS -DST_MTIM_NSEC=$ac_val"
-      AC_TRY_COMPILE([#include <sys/types.h>
+      AC_COMPILE_IFELSE(
+      [AC_LANG_PROGRAM[#include <sys/types.h>
 #include <sys/stat.h>
-	], [struct stat s; s.ST_MTIM_NSEC;],
+	]], [struct stat s; s.ST_MTIM_NSEC;],
         [ac_cv_struct_st_mtim_nsec=$ac_val; break])
     done
     CPPFLAGS="$ac_save_CPPFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,9 @@ AH_TOP(
 #define INCLUDED_REMAKE_CONFIG_H
 )
 AH_BOTTOM(
+/* We assume everyone nowadays has ANSI C header files. */
+/* This is what autoconf now assumes. */
+#define STDC_HEADERS 1
 #endif /*INCLUDED_REMAKE_CONFIG_H*/
 )
 
@@ -107,16 +110,6 @@ AC_SYS_LARGEFILE
 AC_SEARCH_LIBS([strerror],[cposix])
 AC_SEARCH_LIBS([getpwnam], [sun])
 
-# Autoupdate added the next two lines to ensure that your configure
-# script's behavior did not change.  They are probably safe to remove.
-AC_CHECK_INCLUDES_DEFAULT
-AC_PROG_EGREP
-
-# Checks for header files.
-m4_warn([obsolete],
-[The preprocessor macro `STDC_HEADERS' is obsolete.
-  Except in unusual embedded environments, you can safely include all
-  ISO C90 headers unconditionally.])dnl
 # Autoupdate added the next two lines to ensure that your configure
 # script's behavior did not change.  They are probably safe to remove.
 AC_CHECK_INCLUDES_DEFAULT

--- a/doc/make.texi
+++ b/doc/make.texi
@@ -13495,8 +13495,6 @@ INSTALLDATA = /usr/local/bin/install -c -m 644
 @end group
 
 # Things you might add to DEFS:
-# -DSTDC_HEADERS        If you have ANSI C headers and
-#                       libraries.
 # -DPOSIX               If you have POSIX.1 headers and
 #                       libraries.
 # -DBSD42               If you have sys/dir.h (unless

--- a/glob/fnmatch.c
+++ b/glob/fnmatch.c
@@ -36,9 +36,7 @@ USA.  */
 # include <strings.h>
 #endif
 
-#if defined STDC_HEADERS || defined _LIBC
-# include <stdlib.h>
-#endif
+#include <stdlib.h>
 
 /* For platform which support the ISO C amendement 1 functionality we
    support user defined character classes.  */
@@ -59,11 +57,7 @@ USA.  */
 #if defined _LIBC || !defined __GNU_LIBRARY__
 
 
-# if defined STDC_HEADERS || !defined isascii
-#  define ISASCII(c) 1
-# else
-#  define ISASCII(c) isascii(c)
-# endif
+#define ISASCII(c) 1
 
 # ifdef isblank
 #  define ISBLANK(c) (ISASCII (c) && isblank (c))

--- a/glob/glob.c
+++ b/glob/glob.c
@@ -59,9 +59,7 @@ USA.  */
 
 #ifndef ELIDE_CODE
 
-#if defined STDC_HEADERS || defined __GNU_LIBRARY__
-# include <stddef.h>
-#endif
+#include <stddef.h>
 
 #if defined HAVE_UNISTD_H || defined _LIBC
 # include <unistd.h>
@@ -76,7 +74,7 @@ USA.  */
 # include <pwd.h>
 #endif
 
-#if !defined __GNU_LIBRARY__ && !defined STDC_HEADERS
+#if !defined __GNU_LIBRARY__
 extern int errno;
 #endif
 #ifndef __set_errno
@@ -130,31 +128,9 @@ extern int errno;
 # define REAL_DIR_ENTRY(dp) (dp->d_ino != 0)
 #endif /* POSIX */
 
-#if defined STDC_HEADERS || defined __GNU_LIBRARY__
-# include <stdlib.h>
-# include <string.h>
-# define	ANSI_STRING
-#else	/* No standard headers.  */
-
-extern char *getenv ();
-
-# ifdef HAVE_STRING_H
-#  include <string.h>
-#  define ANSI_STRING
-# else
-#  include <strings.h>
-# endif
-# ifdef	HAVE_MEMORY_H
-#  include <memory.h>
-# endif
-
-extern char *malloc (), *realloc ();
-extern void free ();
-
-extern void qsort ();
-extern void abort (), exit ();
-
-#endif	/* Standard headers.  */
+#include <stdlib.h>
+#include <string.h>
+#define	ANSI_STRING
 
 #ifndef	ANSI_STRING
 
@@ -252,7 +228,7 @@ extern char *alloca ();
 # endif
 #endif
 
-#if !(defined STDC_HEADERS || defined __GNU_LIBRARY__)
+#if !defined __GNU_LIBRARY__
 # undef	size_t
 # define size_t	unsigned int
 #endif

--- a/lib/findprog-in.c
+++ b/lib/findprog-in.c
@@ -16,7 +16,7 @@
    along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 
-#include <config.h>
+#include "../src/config.h"
 
 /* Specification.  */
 #include "findprog.h"

--- a/lib/fnmatch.c
+++ b/lib/fnmatch.c
@@ -36,9 +36,7 @@ USA.  */
 # include <strings.h>
 #endif
 
-#if defined STDC_HEADERS || defined _LIBC
-# include <stdlib.h>
-#endif
+#include <stdlib.h>
 
 /* For platform which support the ISO C amendement 1 functionality we
    support user defined character classes.  */
@@ -59,11 +57,7 @@ USA.  */
 #if defined _LIBC || !defined __GNU_LIBRARY__
 
 
-# if defined STDC_HEADERS || !defined isascii
-#  define ISASCII(c) 1
-# else
-#  define ISASCII(c) isascii(c)
-# endif
+#define ISASCII(c) 1
 
 # ifdef isblank
 #  define ISBLANK(c) (ISASCII (c) && isblank (c))

--- a/lib/glob.c
+++ b/lib/glob.c
@@ -59,9 +59,7 @@ USA.  */
 
 #ifndef ELIDE_CODE
 
-#if defined STDC_HEADERS || defined __GNU_LIBRARY__
-# include <stddef.h>
-#endif
+#include <stddef.h>
 
 #if defined HAVE_UNISTD_H || defined _LIBC
 # include <unistd.h>
@@ -76,9 +74,6 @@ USA.  */
 # include <pwd.h>
 #endif
 
-#if !defined __GNU_LIBRARY__ && !defined STDC_HEADERS
-extern int errno;
-#endif
 #ifndef __set_errno
 # define __set_errno(val) errno = (val)
 #endif
@@ -130,31 +125,9 @@ extern int errno;
 # define REAL_DIR_ENTRY(dp) (dp->d_ino != 0)
 #endif /* POSIX */
 
-#if defined STDC_HEADERS || defined __GNU_LIBRARY__
-# include <stdlib.h>
-# include <string.h>
-# define	ANSI_STRING
-#else	/* No standard headers.  */
-
-extern char *getenv ();
-
-# ifdef HAVE_STRING_H
-#  include <string.h>
-#  define ANSI_STRING
-# else
-#  include <strings.h>
-# endif
-# ifdef	HAVE_MEMORY_H
-#  include <memory.h>
-# endif
-
-extern char *malloc (), *realloc ();
-extern void free ();
-
-extern void qsort ();
-extern void abort (), exit ();
-
-#endif	/* Standard headers.  */
+#include <stdlib.h>
+#include <string.h>
+#define	ANSI_STRING
 
 #ifndef	ANSI_STRING
 
@@ -252,7 +225,7 @@ extern char *alloca ();
 # endif
 #endif
 
-#if !(defined STDC_HEADERS || defined __GNU_LIBRARY__)
+#if !defined __GNU_LIBRARY__
 # undef	size_t
 # define size_t	unsigned int
 #endif

--- a/m4/extensions.m4
+++ b/m4/extensions.m4
@@ -163,13 +163,5 @@ dnl configure.ac when using autoheader 2.62.
 # typically due to standards-conformance issues.
 AC_DEFUN_ONCE([gl_USE_SYSTEM_EXTENSIONS],
 [
-  dnl Require this macro before AC_USE_SYSTEM_EXTENSIONS.
-  dnl gnulib does not need it. But if it gets required by third-party macros
-  dnl after AC_USE_SYSTEM_EXTENSIONS is required, autoconf 2.62..2.63 emit a
-  dnl warning: "AC_COMPILE_IFELSE was called before AC_USE_SYSTEM_EXTENSIONS".
-  dnl Note: We can do this only for one of the macros AC_AIX, AC_GNU_SOURCE,
-  dnl AC_MINIX. If people still use AC_AIX or AC_MINIX, they are out of luck.
-  AC_REQUIRE([AC_GNU_SOURCE])
-
   AC_REQUIRE([AC_USE_SYSTEM_EXTENSIONS])
 ])

--- a/m4/malloc.m4
+++ b/m4/malloc.m4
@@ -15,7 +15,7 @@ AC_DEFUN([_AC_FUNC_MALLOC_IF],
     [ac_cv_func_malloc_0_nonnull],
     [AC_RUN_IFELSE(
        [AC_LANG_PROGRAM(
-          [[#if defined STDC_HEADERS || defined HAVE_STDLIB_H
+          [[#if defined HAVE_STDLIB_H
             # include <stdlib.h>
             #else
             char *malloc ();

--- a/src/main.c
+++ b/src/main.c
@@ -56,12 +56,6 @@ extern void initialize_stopchar_map ();
 #ifndef HAVE_UNISTD_H
 int chdir ();
 #endif
-#ifndef STDC_HEADERS
-# ifndef sun                    /* Sun has an incorrect decl in a header.  */
-void exit (int) NORETURN;
-# endif
-double atof ();
-#endif
 
 static void clean_jobserver (int status);
 static void print_data_base (void);

--- a/src/make.h
+++ b/src/make.h
@@ -191,32 +191,9 @@ unsigned int get_path_max (void);
 #endif
 // #define UNUSED  __attribute__ ((unused))
 
-#if defined (STDC_HEADERS) || defined (__GNU_LIBRARY__)
-# include <stdlib.h>
-# include <string.h>
-# define ANSI_STRING 1
-#else   /* No standard headers.  */
-# ifdef HAVE_STRING_H
-#  include <string.h>
-#  define ANSI_STRING 1
-# else
-#  include <strings.h>
-# endif
-# ifdef HAVE_MEMORY_H
-#  include <memory.h>
-# endif
-# ifdef HAVE_STDLIB_H
-#  include <stdlib.h>
-# else
-void *malloc (int);
-void *realloc (void *, int);
-void free (void *);
-
-void abort (void) __attribute__ ((noreturn));
-void exit (int) __attribute__ ((noreturn));
-# endif /* HAVE_STDLIB_H.  */
-
-#endif /* Standard headers.  */
+#include <stdlib.h>
+#include <string.h>
+#define ANSI_STRING 1
 
 /* These should be in stdlib.h.  Make sure we have them.  */
 #ifndef EXIT_SUCCESS

--- a/src/makeint.h
+++ b/src/makeint.h
@@ -239,32 +239,9 @@ unsigned int get_path_max (void);
 #define UNUSED   ATTRIBUTE ((unused))
 #define NORETURN ATTRIBUTE ((noreturn))
 
-#if defined (STDC_HEADERS) || defined (__GNU_LIBRARY__)
-# include <stdlib.h>
-# include <string.h>
-# define ANSI_STRING 1
-#else   /* No standard headers.  */
-# ifdef HAVE_STRING_H
-#  include <string.h>
-#  define ANSI_STRING 1
-# else
-#  include <strings.h>
-# endif
-# ifdef HAVE_MEMORY_H
-#  include <memory.h>
-# endif
-# ifdef HAVE_STDLIB_H
-#  include <stdlib.h>
-# else
-void *malloc (int);
-void *realloc (void *, int);
-void free (void *);
-
-void abort (void) NORETURN;
-void exit (int) NORETURN;
-# endif /* HAVE_STDLIB_H.  */
-
-#endif /* Standard headers.  */
+#include <stdlib.h>
+#include <string.h>
+#define ANSI_STRING 1
 
 /* These should be in stdlib.h.  Make sure we have them.  */
 #ifndef EXIT_SUCCESS


### PR DESCRIPTION
Remove/replace some deprecated autoconf macros. 

In particular, one change is that `STDC_HEADERS` is now assumed.
